### PR TITLE
chore: drop namespace for cluster scoped resources

### DIFF
--- a/controller/resources/rbac.yaml
+++ b/controller/resources/rbac.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: controller-role
-  namespace: default
 rules:
   - apiGroups: ["objectstorage.k8s.io"]
     resources: ["bucketclaims", "bucketaccesses", "bucketclaims/status", "bucketaccesses/status"]
@@ -25,7 +24,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: controller
-  namespace: default
   labels:
     app.kubernetes.io/part-of: container-object-storage-interface
     app.kubernetes.io/component: controller


### PR DESCRIPTION
No need to add namespace for cluster scoped resources