### PR TITLE
Sync main -> release-0.2

### DIFF
--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -23,7 +23,7 @@ export SIDECAR_TAG="${SIDECAR_IMAGE}:${GIT_TAG}"
 export CONTROLLER_TAG="${CONTROLLER_IMAGE}:${GIT_TAG}"
 
 # build in parallel
-make --jobs --output-sync build
+make build
 
 # add latest tag to just-built images
 gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:latest"


### PR DESCRIPTION
Sync the latest main branch changes to release-0.2.

This should resolve the cloudbuild `make build` errors in release-0.2