### PR TITLE
Move away from gcr.io staging repo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@ substitutions:
 steps:
   # TODO: currently gcr.io/k8s-testimages/gcb-docker-gcloud has not moved to Artifact Registry
   # gcr.io will be shut down 18 Mar 2025, and we need replacement before then. Latest info below:
-  # https://github.com/kubernetes/test-infra/blob/master/images/gcb-docker-gcloud/cloudbuild.yaml
+  # https://github.com/kubernetes/k8s.io/issues/1523#issuecomment-920311451
   - id: do-multi-arch-build-all-images
     name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36
     args:

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -29,6 +29,9 @@ RUN CGO_ENABLED=0 go build -o /buildroot/artifacts/controller cmd/*.go
 #
 # FINAL IMAGE
 #
+
+# gcr.io is deprecated, but gcr.io/distroless/static is hosted by artifact hub with the gcr.io path.
+# See: https://github.com/GoogleContainerTools/distroless/issues/1320
 FROM gcr.io/distroless/static:nonroot
 
 LABEL maintainers="Kubernetes Authors"

--- a/hack/Dockerfile.in
+++ b/hack/Dockerfile.in
@@ -27,6 +27,9 @@ RUN CGO_ENABLED=0 go build -o /buildroot/artifacts/{{COMPONENT}} cmd/*.go
 #
 # FINAL IMAGE
 #
+
+# gcr.io is deprecated, but gcr.io/distroless/static is hosted by artifact hub with the gcr.io path.
+# See: https://github.com/GoogleContainerTools/distroless/issues/1320
 FROM gcr.io/distroless/static:nonroot
 
 LABEL maintainers="Kubernetes Authors"

--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -10,7 +10,7 @@ echo "PLATFORM: ${PLATFORM}"
 # debug the rest of the script in case of image/CI build issues
 set -o xtrace
 
-REPO="gcr.io/k8s-staging-sig-storage"
+REPO="registry.k8s.io/k8s-staging-sig-storage"
 
 CONTROLLER_IMAGE="${REPO}/objectstorage-controller"
 SIDECAR_IMAGE="${REPO}/objectstorage-sidecar"

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -29,6 +29,9 @@ RUN CGO_ENABLED=0 go build -o /buildroot/artifacts/sidecar cmd/*.go
 #
 # FINAL IMAGE
 #
+
+# gcr.io is deprecated, but gcr.io/distroless/static is hosted by artifact hub with the gcr.io path.
+# See: https://github.com/GoogleContainerTools/distroless/issues/1320
 FROM gcr.io/distroless/static:nonroot
 
 LABEL maintainers="Kubernetes Authors"


### PR DESCRIPTION
Stage COSI image builds to registry.k8s.io instead of gcr.io. GCR is
being deprecated and will be unavailable 18 Mar 2025.

The gcr.io/k8s-testimages/gcb-docker-gcloud image used by COSI still
doesn't have a non-deprecated image location. Update the TODO note with
the latest info so it can be more easily tracked.

Add a note to uses of gcr.io/distroless/static explaining that it isn't
necessary to migrate gcr.io usage to artifact hub because the
gcr.io/distroless/static image is migrated to be hosted by artifact hub.