### PR TITLE
build: fix repo reference in dockerfiles

### DIFF
--- a/hack/Dockerfile.in
+++ b/hack/Dockerfile.in
@@ -34,7 +34,7 @@ LABEL description="COSI {{COMPONENT}}"
 
 LABEL org.opencontainers.image.title="COSI {{COMPONENT}}"
 LABEL org.opencontainers.image.description="Container Object Storage Interface (COSI) {{COMPONENT}}"
-LABEL org.opencontainers.image.source="https://github.com/kubernetes-sigs/container-object-storage-interface-api/{{COMPONENT}}"
+LABEL org.opencontainers.image.source="https://github.com/kubernetes-sigs/container-object-storage-interface/{{COMPONENT}}"
 LABEL org.opencontainers.image.licenses="APACHE-2.0"
 
 WORKDIR /


### PR DESCRIPTION
Fix an out of sync reference to the old API repository in Dockerfiles.

The controller and sidecar dockerfiles, generated from this Dockerfile.in, are already correct, but .in template doesn't have the change. This was likely a recent minor oversight. Once we implement the prow job to check generated files, this should be prevented in the future.