### PR TITLE
cloudbuild: update tag/release script

### DIFF
--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -22,25 +22,50 @@ export PLATFORM
 export SIDECAR_TAG="${SIDECAR_IMAGE}:${GIT_TAG}"
 export CONTROLLER_TAG="${CONTROLLER_IMAGE}:${GIT_TAG}"
 
-# build in parallel
 make build
 
-# add latest tag to just-built images
-gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:latest"
-gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:latest"
+# PULL_BASE_REF is 'main' for non-tagged commits on the main branch
+if [[ "${PULL_BASE_REF}" == main ]]; then
+  echo " ! ! ! this is a main branch build ! ! !"
+  # 'main' tag follows the main branch head
+  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:main"
+  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:main"
+  # 'latest' tag follows 'main' for easy use by developers
+  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:latest"
+  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:latest"
+fi
 
-# PULL_BASE_REF is 'controller/TAG' for a controller release
+# PULL_BASE_REF is 'release-*' for non-tagged commits on release branches
+if [[ "${PULL_BASE_REF}" == release-* ]]; then
+  echo " ! ! ! this is a ${PULL_BASE_REF} release branch build ! ! !"
+  # 'release-*' tags that follow each release branch head
+  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:${PULL_BASE_REF}"
+  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:${PULL_BASE_REF}"
+fi
+
+# PULL_BASE_REF is 'controller/TAG' for a tagged controller release
 if [[ "${PULL_BASE_REF}" == controller/* ]]; then
   echo " ! ! ! this is a tagged controller release ! ! !"
   TAG="${PULL_BASE_REF#controller/*}"
   gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:${TAG}"
 fi
 
-# PULL_BASE_REF is 'sidecar/TAG' for a controller release
+# PULL_BASE_REF is 'sidecar/TAG' for a tagged sidecar release
 if [[ "${PULL_BASE_REF}" == sidecar/* ]]; then
   echo " ! ! ! this is a tagged sidecar release ! ! !"
   TAG="${PULL_BASE_REF#sidecar/*}"
   gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:${TAG}"
 fi
 
-# else, PULL_BASE_REF is a branch name (e.g., master, release-0.2) or a tag (e.g., client/v0.2.0, proto/v0.2.0)
+# PULL_BASE_REF is 'v0.y.z*' for tagged alpha releases where controller and sidecar are released simultaneously
+# hand wave over complex matching logic by just looking for 'v0.' prefix
+if [[ "${PULL_BASE_REF}" == 'v0.'* ]]; then
+  echo " ! ! ! this is a tagged controller + sidecar release ! ! !"
+  TAG="${PULL_BASE_REF}"
+  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:${TAG}"
+  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:${TAG}"
+fi
+
+# else, PULL_BASE_REF is something that doesn't release image(s) to staging, like:
+#  - a random branch name (e.g., feature-xyz)
+#  - a version tag for a subdir with no image associated (e.g., client/v0.2.0, proto/v0.2.0)


### PR DESCRIPTION
As COSI is working to release v0.2.0 from the new monorepo, ensure images are built and released to staging that are useful for devs and vendor drivers dependent on COSI.

Keep 'main' and 'latest' tags that follow COSI main head that is useful for COSI devs and driver devs, as well as canary-type CI envs.

Keep 'release-*' tags that follow COSI release branches that are useful for CI envs.

Allow tagging COSI commits with standard semver tags like 'v0.2.0' that don't include the 'sidecar/' or 'controller/' prefixes. These tags will release both sidecar and controller images to staging while COSI maintainers talk to sig-storage about releasing individual images from monorepos using the standardized sig-storage prow image tooling.