### PR TITLE
cloudbuild: fix epoch dating on staged image tags

### DIFF
--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -17,44 +17,45 @@ SIDECAR_IMAGE="${REPO}/objectstorage-sidecar"
 
 # args to 'make build'
 export DOCKER="/buildx-entrypoint" # available in gcr.io/k8s-testimages/gcb-docker-gcloud image
-export BUILD_ARGS="--push"
 export PLATFORM
 export SIDECAR_TAG="${SIDECAR_IMAGE}:${GIT_TAG}"
 export CONTROLLER_TAG="${CONTROLLER_IMAGE}:${GIT_TAG}"
 
-make build
+ADDITIONAL_BUILD_ARGS="--push"
+ADDITIONAL_CONTROLLER_TAGS=()
+ADDITIONAL_SIDECAR_TAGS=()
 
 # PULL_BASE_REF is 'main' for non-tagged commits on the main branch
 if [[ "${PULL_BASE_REF}" == main ]]; then
   echo " ! ! ! this is a main branch build ! ! !"
   # 'main' tag follows the main branch head
-  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:main"
-  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:main"
+  ADDITIONAL_CONTROLLER_TAGS+=("${CONTROLLER_IMAGE}:main")
+  ADDITIONAL_SIDECAR_TAGS+=("${SIDECAR_IMAGE}:main")
   # 'latest' tag follows 'main' for easy use by developers
-  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:latest"
-  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:latest"
+  ADDITIONAL_CONTROLLER_TAGS+=("${CONTROLLER_IMAGE}:latest")
+  ADDITIONAL_SIDECAR_TAGS+=("${SIDECAR_IMAGE}:latest")
 fi
 
 # PULL_BASE_REF is 'release-*' for non-tagged commits on release branches
 if [[ "${PULL_BASE_REF}" == release-* ]]; then
   echo " ! ! ! this is a ${PULL_BASE_REF} release branch build ! ! !"
   # 'release-*' tags that follow each release branch head
-  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:${PULL_BASE_REF}"
-  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:${PULL_BASE_REF}"
+  ADDITIONAL_CONTROLLER_TAGS+=("${CONTROLLER_IMAGE}:${PULL_BASE_REF}")
+  ADDITIONAL_SIDECAR_TAGS+=("${SIDECAR_IMAGE}:${PULL_BASE_REF}")
 fi
 
 # PULL_BASE_REF is 'controller/TAG' for a tagged controller release
 if [[ "${PULL_BASE_REF}" == controller/* ]]; then
   echo " ! ! ! this is a tagged controller release ! ! !"
   TAG="${PULL_BASE_REF#controller/*}"
-  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:${TAG}"
+  ADDITIONAL_CONTROLLER_TAGS+=("${CONTROLLER_IMAGE}:${TAG}")
 fi
 
 # PULL_BASE_REF is 'sidecar/TAG' for a tagged sidecar release
 if [[ "${PULL_BASE_REF}" == sidecar/* ]]; then
   echo " ! ! ! this is a tagged sidecar release ! ! !"
   TAG="${PULL_BASE_REF#sidecar/*}"
-  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:${TAG}"
+  ADDITIONAL_SIDECAR_TAGS+=("${SIDECAR_IMAGE}:${TAG}")
 fi
 
 # PULL_BASE_REF is 'v0.y.z*' for tagged alpha releases where controller and sidecar are released simultaneously
@@ -62,10 +63,28 @@ fi
 if [[ "${PULL_BASE_REF}" == 'v0.'* ]]; then
   echo " ! ! ! this is a tagged controller + sidecar release ! ! !"
   TAG="${PULL_BASE_REF}"
-  gcloud container images add-tag "${CONTROLLER_TAG}" "${CONTROLLER_IMAGE}:${TAG}"
-  gcloud container images add-tag "${SIDECAR_TAG}" "${SIDECAR_IMAGE}:${TAG}"
+  ADDITIONAL_CONTROLLER_TAGS+=("${CONTROLLER_IMAGE}:${TAG}")
+  ADDITIONAL_SIDECAR_TAGS+=("${SIDECAR_IMAGE}:${TAG}")
 fi
 
 # else, PULL_BASE_REF is something that doesn't release image(s) to staging, like:
 #  - a random branch name (e.g., feature-xyz)
 #  - a version tag for a subdir with no image associated (e.g., client/v0.2.0, proto/v0.2.0)
+
+# 'gcloud container images add-tag' within the cloudbuild infrastructure doesn't preserve the date
+# of the underlying image when adding a new tag, resulting in tags dated Dec 31, 1969 (the epoch).
+# To ensure the right date on all built image tags, do the build with '--tag' args for all tags.
+
+BUILD_ARGS="${ADDITIONAL_BUILD_ARGS}"
+for tag in "${ADDITIONAL_CONTROLLER_TAGS[@]}"; do
+  BUILD_ARGS="${BUILD_ARGS} --tag=${tag}"
+done
+export BUILD_ARGS
+make build.controller
+
+BUILD_ARGS="${ADDITIONAL_BUILD_ARGS}"
+for tag in "${ADDITIONAL_SIDECAR_TAGS[@]}"; do
+  BUILD_ARGS="${BUILD_ARGS} --tag=${tag}"
+done
+export BUILD_ARGS
+make build.sidecar


### PR DESCRIPTION
Using `gcloud container images add-tag` to add tags to images built and pushed to GCR was resulting in the added tags having a date of Dec. 31, 1969 (the epoch). In order to avoid tags having epoch dates, adjust the cloudbuild script to use `--tag` arguments for each tag.

I did a dry run of this, and I think everything looks right

```
GIT_TAG: hash-v0.2.0-stuff
PULL_BASE_REF: v0.2.0
PLATFORM: linux/amd64,linux/arm64
+ REPO=gcr.io/k8s-staging-sig-storage
+ CONTROLLER_IMAGE=gcr.io/k8s-staging-sig-storage/objectstorage-controller
+ SIDECAR_IMAGE=gcr.io/k8s-staging-sig-storage/objectstorage-sidecar
+ export DOCKER=/buildx-entrypoint
+ DOCKER=/buildx-entrypoint
+ export PLATFORM
+ export SIDECAR_TAG=gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:hash-v0.2.0-stuff
+ SIDECAR_TAG=gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:hash-v0.2.0-stuff
+ export CONTROLLER_TAG=gcr.io/k8s-staging-sig-storage/objectstorage-controller:hash-v0.2.0-stuff
+ CONTROLLER_TAG=gcr.io/k8s-staging-sig-storage/objectstorage-controller:hash-v0.2.0-stuff
+ ADDITIONAL_BUILD_ARGS=--push
+ ADDITIONAL_CONTROLLER_TAGS=()
+ ADDITIONAL_SIDECAR_TAGS=()
+ [[ v0.2.0 == main ]]
+ [[ v0.2.0 == release-* ]]
+ [[ v0.2.0 == controller/* ]]
+ [[ v0.2.0 == sidecar/* ]]
+ [[ v0.2.0 == \v\0\.* ]]
+ echo ' ! ! ! this is a tagged controller + sidecar release ! ! !'
 ! ! ! this is a tagged controller + sidecar release ! ! !
+ TAG=v0.2.0
+ ADDITIONAL_CONTROLLER_TAGS+=("${CONTROLLER_IMAGE}:${TAG}")
+ ADDITIONAL_SIDECAR_TAGS+=("${SIDECAR_IMAGE}:${TAG}")
+ BUILD_ARGS=--push
+ for tag in "${ADDITIONAL_CONTROLLER_TAGS[@]}"
+ BUILD_ARGS='--push --tag=gcr.io/k8s-staging-sig-storage/objectstorage-controller:v0.2.0'
+ export BUILD_ARGS
+ echo make build.controller
make build.controller
+ BUILD_ARGS=--push
+ for tag in "${ADDITIONAL_SIDECAR_TAGS[@]}"
+ BUILD_ARGS='--push --tag=gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v0.2.0'
+ export BUILD_ARGS
+ echo make build.sidecar
make build.sidecar
```