### PR TITLE
dependabot: add ok-to-test label to PRs automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,15 +19,21 @@ updates:
         exclude-patterns:
           # controller-runtime has history of breaking API changes more often than other k8s projects
           - "sigs.k8s.io/controller-runtime"
+    labels:
+      - ok-to-test
 
   - package-ecosystem: "docker"
     directories:
       - "**/*"
     schedule:
       interval: "weekly"
+    labels:
+      - ok-to-test
 
   - package-ecosystem: "github-actions"
     directories:
       - "**/*"
     schedule:
       interval: "weekly"
+    labels:
+      - ok-to-test


### PR DESCRIPTION
Attempt to have dependabot add the `ok-to-test` label to its PRs automatically. Dependabot is a trustworthy bot built into GitHub, and having its PRs tested automatically will help maintain dependency updates with a little less friction and time.