### PR TITLE
ci: add prow lint/test scripts w/ CPU limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,12 @@ test-e2e: chainsaw # Run e2e tests against the K8s cluster specified in ~/.kube/
 .PHONY: lint
 lint: golangci-lint.client golangci-lint.controller golangci-lint.sidecar ## Run all linters (suggest `make -k`)
 golangci-lint.%: golangci-lint
-	cd $* && $(GOLANGCI_LINT) run --config $(CURDIR)/.golangci.yaml --new
+	cd $* && $(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml --new
 
 .PHONY: lint-fix
 lint-fix: golangci-lint-fix.client golangci-lint-fix.controller golangci-lint-fix.sidecar ## Run all linters and perform fixes where possible (suggest `make -k`)
 golangci-lint-fix.%: golangci-lint
-	cd $* && $(GOLANGCI_LINT) run --config $(CURDIR)/.golangci.yaml --new --fix
+	cd $* && $(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml --new --fix
 
 ##@ Build
 

--- a/hack/prow-lint.sh
+++ b/hack/prow-lint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o xtrace
+
+GOLANGCI_LINT_RUN_OPTS=""
+GOLANGCI_LINT_RUN_OPTS="$GOLANGCI_LINT_RUN_OPTS --verbose" # debug linter timing and mem usage
+GOLANGCI_LINT_RUN_OPTS="$GOLANGCI_LINT_RUN_OPTS --concurrency=2" # prow job lags if too many threads
+export GOLANGCI_LINT_RUN_OPTS
+
+make lint

--- a/hack/prow-test.sh
+++ b/hack/prow-test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o xtrace
+
+export GOMAXPROCS=2 # prow job lags if too many threads
+
+make test


### PR DESCRIPTION
Unit tests and golangci-lint are taking a long time to run in Prow environments, sometimes timing out and causing CI flakes. Likely, this is a result of the CI detecting the number of CPUs on the host, yet being limited to fewer CPUs (2 currently) in the Prow job config.

Regardless of whether Prow jobs are updated to allow more CPU/memory usage, it is still important to be able to limit concurrency to what is configured in the job to avoid the issue if Prow machines become significantly bigger in the future.

Prow jobs will need to be updated to make use of these new scripts.