### PR TITLE
prow: debug GOMAXPROCS instead of setting it

### DIFF
--- a/hack/prow-lint.sh
+++ b/hack/prow-lint.sh
@@ -3,9 +3,11 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
+echo "GOMAXPROCS: $GOMAXPROCS" # debug prow CPU limit to ensure job not being throttled
+
 GOLANGCI_LINT_RUN_OPTS=""
 GOLANGCI_LINT_RUN_OPTS="$GOLANGCI_LINT_RUN_OPTS --verbose" # debug linter timing and mem usage
-GOLANGCI_LINT_RUN_OPTS="$GOLANGCI_LINT_RUN_OPTS --concurrency=2" # prow job lags if too many threads
+GOLANGCI_LINT_RUN_OPTS="$GOLANGCI_LINT_RUN_OPTS --concurrency=$GOMAXPROCS" # golangci-lint seems to do a bad job obeying GOMAXPROCS
 export GOLANGCI_LINT_RUN_OPTS
 
 make lint

--- a/hack/prow-test.sh
+++ b/hack/prow-test.sh
@@ -3,6 +3,6 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
-export GOMAXPROCS=2 # prow job lags if too many threads
+echo "GOMAXPROCS: $GOMAXPROCS" # debug prow CPU limit to ensure job not being throttled
 
 make test


### PR DESCRIPTION
GOMAXPROCS is now being set in the prow job config. However, the issue of unit tests and lint runs being throttled could still be a risk. Instead of setting a hardcoded GOMAXPROCS value, log the value in the test/lint runs so we can debug any potential issues in the future.

Starting this as draft because I want to run several prow runs to observe mem/cpu usage and see whether there are still flakes

[update] this seems to keep the max CPU usage to around 2, so I think it's working with GOMAXPROCS in the prow job. That said, it does spike up to 2.5 CPU, and the tests still take a little over 6 minutes to run all of the submodule tests/linting. golangci-lint in particular seems to want more resources. I am following up to increase the resources given to the prow jobs here: https://github.com/kubernetes/test-infra/pull/34745 