### PR TITLE
Feat: Add linter for dockerfiles [hadolint]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,13 @@ test-e2e: chainsaw # Run e2e tests against the K8s cluster specified in ~/.kube/
 	$(CHAINSAW) test --values ./test/e2e/values.yaml
 
 .PHONY: lint
-lint: golangci-lint.client golangci-lint.controller golangci-lint.sidecar spell-lint ## Run all linters (suggest `make -k`)
+lint: golangci-lint.client golangci-lint.controller golangci-lint.sidecar spell-lint dockerfiles-lint ## Run all linters (suggest `make -k`)
 golangci-lint.%: golangci-lint
 	cd $* && $(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml --new
 spell-lint:
 	git ls-files | grep -v -e CHANGELOG -e go.mod -e go.sum -e vendor | xargs $(SPELL_LINT) -i "Creater,creater,ect" -error -o stderr
+dockerfiles-lint:
+	hack/tools/lint-dockerfiles.sh $(HADOLINT_VERSION)
 
 .PHONY: lint-fix
 lint-fix: golangci-lint-fix.client golangci-lint-fix.controller golangci-lint-fix.sidecar ## Run all linters and perform fixes where possible (suggest `make -k`)
@@ -180,6 +182,7 @@ KIND_VERSION          ?= v0.27.0
 KUSTOMIZE_VERSION     ?= v5.6.0
 MDBOOK_VERSION        ?= v0.4.47
 SPELL_LINT_VERSION    ?= v0.6.0
+HADOLINT_VERSION      ?= v2.12.0
 
 .PHONY: chainsaw
 chainsaw: $(CHAINSAW)-$(CHAINSAW_VERSION)

--- a/hack/tools/lint-dockerfiles.sh
+++ b/hack/tools/lint-dockerfiles.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eu
+
+HADOLINT_VERSION=${1:-latest}
+
+FILES=$(find . -path './vendor' -prune -o -name Dockerfile -print)
+
+IFS=$'\n'
+
+for file in $FILES; do
+  echo "Linting: ${file}"
+  docker run --rm -i ghcr.io/hadolint/hadolint:"${HADOLINT_VERSION}" hadolint --failure-threshold warning - < "${file}"
+done
+
+unset IFS


### PR DESCRIPTION
Part of #9 

Add linter for dockerfiles using hadolint.

Included `dockerfiles-lint` target into lint makefile target

Current files which are included for linting,
- `controller/Dockerfile`
- `sidecar/Dockerfile`

Excluding any docker files present in `./vendor` directory, such as
-  `vendor/github.com/pelletier/go-toml/v2/Dockerfile`