### PR TITLE
update readme and gh templates for v1alpha2 work

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,12 +1,17 @@
 ---
 name: Bug Report
-about: Use this template for reporting bugs or issues.
-title: "[DATE] - Title"
-labels: bug
+about: Use THIS AND ONLY THIS template for reporting bugs or issues
+title: "Title"
+labels: "kind/bug"
 ---
 # Bug Report
 
-<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+<!--
+You MUST use this template while reporting a bug.
+Provide as much info as possible so that we may understand the issue and assist.
+Enclose all log/console output in triple-backticks.
+Issues that do not fill in this template or follow its guidelines will be closed.
+Thanks!
 
 If the matter is security related, please disclose it privately via https://kubernetes.io/security/
 -->
@@ -18,6 +23,35 @@ If the matter is security related, please disclose it privately via https://kube
 **How to reproduce this bug (as minimally and precisely as possible)**:
 
 **Anything else relevant for this bug report?**:
+
+**Resources and logs to submit**:
+
+Copy all relevant COSI resources here in yaml format:
+
+```yaml
+# BucketClass
+# BucketAccessClass
+# BucketClaim
+# Bucket
+# BucketAccess
+```
+
+```
+# Copy COSI controller pod logs here
+```
+
+```
+# Copy COSI sidecar logs here for the relevant driver
+```
+
+<!--
+To get resources in yaml format, use `kubectl -n <namespace> get -o yaml`
+To get logs, use `kubectl -n <namespace> logs <pod name>`
+
+When pasting logs, always surround them with triple-backticks.
+Read the GitHub documentation if you need help:
+https://help.github.com/en/articles/creating-and-highlighting-code-blocks
+-->
 
 **Environment**:
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,18 +1,26 @@
 ---
 name: Enhancement/Feature Request
 about: Use this template to request a new feature or enhancement for the COSI API
-title: "[DATE] - Title"
+title: "Title"
+labels: "kind/feature"
 ---
 # Enhancement
 
-**Is your feature request related to a problem?/Why is this needed**
-<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+<!--
+You MUST use this template when requesting an enhancement.
+Provide as much info as possible so that we may assist in a timely manner.
+Enclose all log/console output in triple-backticks.
+Thanks!
+-->
 
-**Describe the solution you'd like in detail**
+**Why is this needed?**:
+<!-- A clear and concise description of the limitation with the current COSI API. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like in detail**:
 <!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
+**Describe alternatives you've considered**:
 <!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
+**Additional context**:
 <!-- Add any other context or screenshots about the feature request or enhancement here. -->

--- a/.github/ISSUE_TEMPLATE/protocol_change.md
+++ b/.github/ISSUE_TEMPLATE/protocol_change.md
@@ -1,0 +1,35 @@
+---
+name: Protocol Change Request
+about: Use this template to request an API change for an object storage protocol (e.g., S3, Azure, GCP)
+title: "[RFC] Changes to protocol <XYZ>"
+labels: "kind/api-change"
+---
+# Protocol change request
+
+<!--
+You MUST use this template while requesting a protocol change.
+Provide as much info as possible so that we may assist in a timely manner.
+Enclose all log/console output in triple-backticks.
+Thanks!
+-->
+
+**Protocol**:
+<!-- e.g., S3, Azure, GCP, or a new protocol -->
+
+**Fields Added**:
+<!-- Propose fields that need to be added to the current protocol's API. For a new protocol, please propose all fields that are or may become relevant. -->
+
+**Why is this change necessary?**:
+<!-- Explain the limitations of the current protocol API. -->
+
+**Are any workarounds possible with the current API?**:
+<!-- If possible, describe a workaround that allows the current protocol API to support desired usage. -->
+
+**Are other COSI projects/drivers affected by this change?**:
+<!-- If yes, describe how they may be affected. -->
+
+**Upgrade plan**:
+<!-- Proposal for how affected projects/drivers should handle possible upgrade issues. -->
+
+**Additional context**:
+<!-- Add any other context about the RFC here. -->

--- a/README.md
+++ b/README.md
@@ -1,52 +1,50 @@
-![version](https://img.shields.io/badge/status-pre--alpha-lightgrey) ![apiVersion](https://img.shields.io/badge/apiVersion-v1alpha1-lightgreen)
-
+![status](https://img.shields.io/badge/status-pre--alpha-lightblue)
+![apiVersion](https://img.shields.io/badge/apiVersion-v1alpha2-lightblue)
+[![docs](https://img.shields.io/badge/docs-latest-lightblue)](https://container-object-storage-interface.sigs.k8s.io/)
 
 # Container Object Storage Interface
 
 This repository hosts the Container Object Storage Interface (COSI) project.
 
+> [!IMPORTANT]
+> This `main` branch contains pre-alpha code and APIs for COSI `v1alpha2`.<br>
+> For `v1alpha1` APIs, code, or development, use branch `release-0.2`
+
 ## Documentation
 
 To deploy, run `kubectl apply -k .`
 
-## Developer Guide
-
-All API definitions are in [`client/apis/objectstorage`](./client/apis/objectstorage/). All API changes **_MUST_** satisfy the following requirements:
-
-- Must be backwards compatible
-- Must be in-sync with the API definitions in [sigs.k8s.io/container-object-storage-interface-spec](https://sigs.k8s.io/container-object-storage-interface-spec)
-
-### Build and Test
-
-See `make help` for assistance
-
-## Adding new fields to protocols
-
-Create a new issue raising a RFC for the changes following this format:
-
-**Title:** [RFC] Changes to protocol xyz
-
-**Description:**
-> 1. Protocol:
-> 2. Fields Added:
-> 3. Why is this change necessary?
->    ...(describe why here)...
-> 4. Which other COSI projects are affected by this change?
-> 5. Upgrade plan
->    (ignore if it doesn't apply)
+Documentation can be found under: https://container-object-storage-interface.sigs.k8s.io/
 
 ## References
 
- - Weekly Meetings: Thursdays from 13:30 to 14:00 US Eastern Time
- - [Roadmap](https://github.com/orgs/kubernetes-sigs/projects/63/)
+- [Weekly meetings](https://www.kubernetes.dev/resources/calendar/): Thursdays from 13:30 to 14:00 US Eastern Time
+- [Roadmap](https://github.com/orgs/kubernetes-sigs/projects/63/)
 
 ## Community, discussion, contribution, and support
 
 You can reach the maintainers of this project at:
 
- - [#sig-storage-cosi](https://kubernetes.slack.com/messages/sig-storage-cosi) slack channel
- - [container-object-storage-interface](https://groups.google.com/g/container-object-storage-interface-wg?pli=1) mailing list
+- [#sig-storage-cosi](https://kubernetes.slack.com/messages/sig-storage-cosi) Slack channel **(preferred)**
+- [GitHub Issues](https://github.com/kubernetes-sigs/container-object-storage-interface/issues)
+- [container-object-storage-interface](https://groups.google.com/g/container-object-storage-interface-wg) mailing list
 
 ### Code of conduct
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
+
+## Developer Guide
+
+Before contributing a Pull Request, ensure a [GitHub
+issue](https://github.com/kubernetes-sigs/container-object-storage-interface/issues) exists corresponding to the change.
+
+All API definitions and behavior must follow the [`v1alpha2` KEP PR](https://github.com/kubernetes/enhancements/pull/4599).
+Minor deviation from the KEP is acceptable in order to fix bugs.
+
+`v1alpha2` is currently pre-release.
+Changes may break compatibility up until `v1alpha2` is released with a semver tag.
+After the first `v1alpha2` semver release (e.g., 0.3.0), all changes must be backwards compatible.
+
+### Build and Test
+
+See `make help` for assistance


### PR DESCRIPTION
Tidy up the main readme, and make sure it is clear that the current (main) branch houses pre-alpha v1alpha2 work. Any v1alpha1 work should use the release-0.2 branch.

Move one of the developer guide topics to a new GitHub issue template, and tidy up the existing issue templates. Remove `[DATE]` from them, which is not used by current maintainers. Clarify in the instructions that reports should include info needed for debugging or risk being closed due to lack of info.