### PR TITLE
add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# ignore dot directories to speed up docker builds where context must be copied
+./.*
+./proto/.*/


### PR DESCRIPTION
Add a .dockerignore file that ignores hidden directories. On MacOS or other environments that run a VM for container building, copying the build context can take quite a bit of time.

Currently, ./.git, ./.cache, ./proto/.build, and ./proto/.protoc amount to over 150MB of context that is not needed for builds to succed.

The vendor dir is still passed to the build context.