### PR TITLE
Exit with error status on error

### DIFF
--- a/sidecar/cmd/main.go
+++ b/sidecar/cmd/main.go
@@ -42,5 +42,6 @@ func main() {
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		klog.ErrorS(err, "Exiting on error")
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
I encountered an error state where the driver and sidecar were both in CrashLoopBackOff, apparently because the socket was in a bad state. However, it appears that both the driver (ceph) and the sidecar were exiting 0. I haven't been able to reproduce the problem yet, but noticed that in what's clearly an error case it appears that the sidecar could still exit 0 and hypothesized that this could improve the behavior.