### PR TITLE
update gcb-docker-gcloud image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,11 +14,8 @@ substitutions:
   # COSI substitutions:
   _PLATFORMS: linux/amd64,linux/arm64 # add more platforms here if desired
 steps:
-  # TODO: currently gcr.io/k8s-testimages/gcb-docker-gcloud has not moved to Artifact Registry
-  # gcr.io will be shut down 18 Mar 2025, and we need replacement before then. Latest info below:
-  # https://github.com/kubernetes/test-infra/blob/master/images/gcb-docker-gcloud/cloudbuild.yaml
   - id: do-multi-arch-build-all-images
-    name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36
+    name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
     args:
       - hack/cloudbuild.sh
     env:

--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -16,7 +16,7 @@ CONTROLLER_IMAGE="${REPO}/objectstorage-controller"
 SIDECAR_IMAGE="${REPO}/objectstorage-sidecar"
 
 # args to 'make build'
-export DOCKER="/buildx-entrypoint" # available in gcr.io/k8s-testimages/gcb-docker-gcloud image
+export DOCKER="/buildx-entrypoint" # available in gcr.io/k8s-staging-test-infra/gcb-docker-gcloud image
 export PLATFORM
 export SIDECAR_TAG="${SIDECAR_IMAGE}:${GIT_TAG}"
 export CONTROLLER_TAG="${CONTROLLER_IMAGE}:${GIT_TAG}"


### PR DESCRIPTION
Update the gcp-docker-gcloud image used for COSI's "Cloudbuild."

The latest recommendation from K8s infra is to use `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud`.

Also update the image version to the latest tag.

Resolves #70 