### PR TITLE
generate docs for v1a2 API without removing v1a1 docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,12 +116,12 @@ build.sidecar: sidecar/Dockerfile ## Build only the sidecar container image
 .PHONY: build-docs
 build-docs: generate crd-ref-docs mdbook
 	@echo "build-docs is temporarily disabled for v1alpha2 development"
-# 	$(CRD_REF_DOCS) \
-# 		--config=./docs/.crd-ref-docs.yaml \
-# 		--source-path=./client/apis \
-# 		--renderer=markdown \
-# 		--output-path=./docs/src/api/
-# 	cd docs; $(MDBOOK) build
+	$(CRD_REF_DOCS) \
+		--config=./docs/.crd-ref-docs.yaml \
+		--source-path=./client/apis \
+		--renderer=markdown \
+		--output-path=./docs/src/api/
+	cd docs; $(MDBOOK) build
 
 MDBOOK_PORT ?= 3000
 

--- a/docs/.crd-ref-docs.yaml
+++ b/docs/.crd-ref-docs.yaml
@@ -5,4 +5,4 @@ processor:
   ignoreFields: []
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: '1.32'
+  kubernetesVersion: '1.34'

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,4 +13,6 @@
     - [Go](./developing/clients/go.md)
     <!-- TODO(guides): add new guides -->
 - [Drivers](./drivers.md)
-- [API Reference](./api/out.md)
+- [API Reference](./api/apis.md)
+  - [v1alpha1](./api/v1alpha1.md)
+  - [v1alpha2](./api/out.md)

--- a/docs/src/api/apis.md
+++ b/docs/src/api/apis.md
@@ -1,0 +1,3 @@
+# API Reference
+
+API Reference provides API Schema definitions for COSI's `objectstorage.k8s.io` API group.

--- a/docs/src/api/out.md
+++ b/docs/src/api/out.md
@@ -1,36 +1,32 @@
 # API Reference
 
 ## Packages
-- [objectstorage.k8s.io/v1alpha1](#objectstoragek8siov1alpha1)
+- [objectstorage.k8s.io/v1alpha2](#objectstoragek8siov1alpha2)
 
 
-## objectstorage.k8s.io/v1alpha1
+## objectstorage.k8s.io/v1alpha2
 
+Package v1alpha2 contains API Schema definitions for the objectstorage v1alpha2 API group.
 
-
-
-#### AuthenticationType
-
-_Underlying type:_ _string_
-
-
-
-
-
-_Appears in:_
+### Resource Types
+- [Bucket](#bucket)
+- [BucketAccess](#bucketaccess)
 - [BucketAccessClass](#bucketaccessclass)
+- [BucketAccessClassList](#bucketaccessclasslist)
+- [BucketAccessList](#bucketaccesslist)
+- [BucketClaim](#bucketclaim)
+- [BucketClaimList](#bucketclaimlist)
+- [BucketClass](#bucketclass)
+- [BucketClassList](#bucketclasslist)
+- [BucketList](#bucketlist)
 
-| Field | Description |
-| --- | --- |
-| `Key` |  |
-| `IAM` |  |
 
 
 #### Bucket
 
 
 
-
+Bucket is the Schema for the buckets API
 
 
 
@@ -39,18 +35,20 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `Bucket` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[BucketSpec](#bucketspec)_ |  |  |  |
-| `status` _[BucketStatus](#bucketstatus)_ |  |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[BucketSpec](#bucketspec)_ | spec defines the desired state of Bucket |  |  |
+| `status` _[BucketStatus](#bucketstatus)_ | status defines the observed state of Bucket |  |  |
 
 
 #### BucketAccess
 
 
 
-
+BucketAccess is the Schema for the bucketaccesses API
 
 
 
@@ -59,18 +57,20 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketAccess` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[BucketAccessSpec](#bucketaccessspec)_ |  |  |  |
-| `status` _[BucketAccessStatus](#bucketaccessstatus)_ |  |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[BucketAccessSpec](#bucketaccessspec)_ | spec defines the desired state of BucketAccess |  |  |
+| `status` _[BucketAccessStatus](#bucketaccessstatus)_ | status defines the observed state of BucketAccess |  |  |
 
 
 #### BucketAccessClass
 
 
 
-
+BucketAccessClass is the Schema for the bucketaccessclasses API
 
 
 
@@ -79,23 +79,92 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketAccessClass` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `driverName` _string_ | DriverName is the name of driver associated with<br />this BucketAccess |  |  |
-| `authenticationType` _[AuthenticationType](#authenticationtype)_ | AuthenticationType denotes the style of authentication<br />It can be one of<br />Key - access, secret tokens based authentication<br />IAM - implicit authentication of pods to the OSP based on service account mappings |  |  |
-| `parameters` _object (keys:string, values:string)_ | Parameters is an opaque map for passing in configuration to a driver<br />for granting access to a bucket |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[BucketAccessClassSpec](#bucketaccessclassspec)_ | spec defines the desired state of BucketAccessClass |  |  |
+| `status` _[BucketAccessClassStatus](#bucketaccessclassstatus)_ | status defines the observed state of BucketAccessClass |  |  |
+
+
+#### BucketAccessClassList
+
+
+
+BucketAccessClassList contains a list of BucketAccessClass
 
 
 
 
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketAccessClassList` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[BucketAccessClass](#bucketaccessclass) array_ |  |  |  |
+
+
+#### BucketAccessClassSpec
+
+
+
+BucketAccessClassSpec defines the desired state of BucketAccessClass
+
+
+
+_Appears in:_
+- [BucketAccessClass](#bucketaccessclass)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `foo` _string_ | foo is an example field of BucketAccessClass. Edit bucketaccessclass_types.go to remove/update |  |  |
+
+
+#### BucketAccessClassStatus
+
+
+
+BucketAccessClassStatus defines the observed state of BucketAccessClass.
+
+
+
+_Appears in:_
+- [BucketAccessClass](#bucketaccessclass)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#condition-v1-meta) array_ | conditions represent the current state of the BucketAccessClass resource.<br />Each condition has a unique type and reflects the status of a specific aspect of the resource.<br /><br />Standard condition types include:<br />- "Available": the resource is fully functional<br />- "Progressing": the resource is being created or updated<br />- "Degraded": the resource failed to reach or maintain its desired state<br /><br />The status of each condition is one of True, False, or Unknown. |  |  |
+
+
+#### BucketAccessList
+
+
+
+BucketAccessList contains a list of BucketAccess
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketAccessList` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[BucketAccess](#bucketaccess) array_ |  |  |  |
 
 
 #### BucketAccessSpec
 
 
 
-
+BucketAccessSpec defines the desired state of BucketAccess
 
 
 
@@ -104,18 +173,14 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `bucketClaimName` _string_ | BucketClaimName is the name of the BucketClaim. |  |  |
-| `protocol` _[Protocol](#protocol)_ | Protocol is the name of the Protocol<br />that this access credential is supposed to support<br />If left empty, it will choose the protocol supported<br />by the bucket. If the bucket supports multiple protocols,<br />the end protocol is determined by the driver. |  |  |
-| `bucketAccessClassName` _string_ | BucketAccessClassName is the name of the BucketAccessClass |  |  |
-| `credentialsSecretName` _string_ | CredentialsSecretName is the name of the secret that COSI should populate<br />with the credentials. If a secret by this name already exists, then it is<br />assumed that credentials have already been generated. It is not overridden.<br />This secret is deleted when the BucketAccess is delted. |  |  |
-| `serviceAccountName` _string_ | ServiceAccountName is the name of the serviceAccount that COSI will map<br />to the OSP service account when IAM styled authentication is specified |  |  |
+| `foo` _string_ | foo is an example field of BucketAccess. Edit bucketaccess_types.go to remove/update |  |  |
 
 
 #### BucketAccessStatus
 
 
 
-
+BucketAccessStatus defines the observed state of BucketAccess.
 
 
 
@@ -124,15 +189,14 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `accountID` _string_ | AccountID is the unique ID for the account in the OSP. It will be populated<br />by the COSI sidecar once access has been successfully granted. |  |  |
-| `accessGranted` _boolean_ | AccessGranted indicates the successful grant of privileges to access the bucket |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#condition-v1-meta) array_ | conditions represent the current state of the BucketAccess resource.<br />Each condition has a unique type and reflects the status of a specific aspect of the resource.<br /><br />Standard condition types include:<br />- "Available": the resource is fully functional<br />- "Progressing": the resource is being created or updated<br />- "Degraded": the resource failed to reach or maintain its desired state<br /><br />The status of each condition is one of True, False, or Unknown. |  |  |
 
 
 #### BucketClaim
 
 
 
-
+BucketClaim is the Schema for the bucketclaims API
 
 
 
@@ -141,20 +205,40 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketClaim` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[BucketClaimSpec](#bucketclaimspec)_ |  |  |  |
-| `status` _[BucketClaimStatus](#bucketclaimstatus)_ |  |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[BucketClaimSpec](#bucketclaimspec)_ | spec defines the desired state of BucketClaim |  |  |
+| `status` _[BucketClaimStatus](#bucketclaimstatus)_ | status defines the observed state of BucketClaim |  |  |
 
 
+#### BucketClaimList
+
+
+
+BucketClaimList contains a list of BucketClaim
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketClaimList` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[BucketClaim](#bucketclaim) array_ |  |  |  |
 
 
 #### BucketClaimSpec
 
 
 
-
+BucketClaimSpec defines the desired state of BucketClaim
 
 
 
@@ -163,16 +247,14 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `bucketClassName` _string_ | Name of the BucketClass |  |  |
-| `protocols` _[Protocol](#protocol) array_ | Protocols are the set of data API this bucket is required to support.<br />The possible values for protocol are:<br />-  S3: Indicates Amazon S3 protocol<br />-  Azure: Indicates Microsoft Azure BlobStore protocol<br />-  GCS: Indicates Google Cloud Storage protocol |  |  |
-| `existingBucketName` _string_ | Name of a bucket object that was manually<br />created to import a bucket created outside of COSI<br />If unspecified, then a new Bucket will be dynamically provisioned |  |  |
+| `foo` _string_ | foo is an example field of BucketClaim. Edit bucketclaim_types.go to remove/update |  |  |
 
 
 #### BucketClaimStatus
 
 
 
-
+BucketClaimStatus defines the observed state of BucketClaim.
 
 
 
@@ -181,15 +263,14 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `bucketReady` _boolean_ | BucketReady indicates that the bucket is ready for consumpotion<br />by workloads |  |  |
-| `bucketName` _string_ | BucketName is the name of the provisioned Bucket in response<br />to this BucketClaim. It is generated and set by the COSI controller<br />before making the creation request to the OSP backend. |  |  |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#condition-v1-meta) array_ | conditions represent the current state of the BucketClaim resource.<br />Each condition has a unique type and reflects the status of a specific aspect of the resource.<br /><br />Standard condition types include:<br />- "Available": the resource is fully functional<br />- "Progressing": the resource is being created or updated<br />- "Degraded": the resource failed to reach or maintain its desired state<br /><br />The status of each condition is one of True, False, or Unknown. |  |  |
 
 
 #### BucketClass
 
 
 
-
+BucketClass is the Schema for the bucketclasses API
 
 
 
@@ -198,23 +279,92 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketClass` | | |
 | `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
 | `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `driverName` _string_ | DriverName is the name of driver associated with this bucket |  |  |
-| `deletionPolicy` _[DeletionPolicy](#deletionpolicy)_ | DeletionPolicy is used to specify how COSI should handle deletion of this<br />bucket. There are 2 possible values:<br /> - Retain: Indicates that the bucket should not be deleted from the OSP<br /> - Delete: Indicates that the bucket should be deleted from the OSP<br />       once all the workloads accessing this bucket are done | Retain |  |
-| `parameters` _object (keys:string, values:string)_ | Parameters is an opaque map for passing in configuration to a driver<br />for creating the bucket |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[BucketClassSpec](#bucketclassspec)_ | spec defines the desired state of BucketClass |  |  |
+| `status` _[BucketClassStatus](#bucketclassstatus)_ | status defines the observed state of BucketClass |  |  |
+
+
+#### BucketClassList
+
+
+
+BucketClassList contains a list of BucketClass
 
 
 
 
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketClassList` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[BucketClass](#bucketclass) array_ |  |  |  |
+
+
+#### BucketClassSpec
+
+
+
+BucketClassSpec defines the desired state of BucketClass
+
+
+
+_Appears in:_
+- [BucketClass](#bucketclass)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `foo` _string_ | foo is an example field of BucketClass. Edit bucketclass_types.go to remove/update |  |  |
+
+
+#### BucketClassStatus
+
+
+
+BucketClassStatus defines the observed state of BucketClass.
+
+
+
+_Appears in:_
+- [BucketClass](#bucketclass)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#condition-v1-meta) array_ | conditions represent the current state of the BucketClass resource.<br />Each condition has a unique type and reflects the status of a specific aspect of the resource.<br /><br />Standard condition types include:<br />- "Available": the resource is fully functional<br />- "Progressing": the resource is being created or updated<br />- "Degraded": the resource failed to reach or maintain its desired state<br /><br />The status of each condition is one of True, False, or Unknown. |  |  |
+
+
+#### BucketList
+
+
+
+BucketList contains a list of Bucket
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `objectstorage.k8s.io/v1alpha2` | | |
+| `kind` _string_ | `BucketList` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[Bucket](#bucket) array_ |  |  |  |
 
 
 #### BucketSpec
 
 
 
-
+BucketSpec defines the desired state of Bucket
 
 
 
@@ -223,67 +373,19 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `driverName` _string_ | DriverName is the name of driver associated with this bucket |  |  |
-| `bucketClassName` _string_ | Name of the BucketClass specified in the BucketRequest |  |  |
-| `bucketClaim` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core)_ | Name of the BucketClaim that resulted in the creation of this Bucket<br />In case the Bucket object was created manually, then this should refer<br />to the BucketClaim with which this Bucket should be bound |  |  |
-| `protocols` _[Protocol](#protocol) array_ | Protocols are the set of data APIs this bucket is expected to support.<br />The possible values for protocol are:<br />-  S3: Indicates Amazon S3 protocol<br />-  Azure: Indicates Microsoft Azure BlobStore protocol<br />-  GCS: Indicates Google Cloud Storage protocol |  |  |
-| `parameters` _object (keys:string, values:string)_ |  |  |  |
-| `deletionPolicy` _[DeletionPolicy](#deletionpolicy)_ | DeletionPolicy is used to specify how COSI should handle deletion of this<br />bucket. There are 2 possible values:<br /> - Retain: Indicates that the bucket should not be deleted from the OSP (default)<br /> - Delete: Indicates that the bucket should be deleted from the OSP<br />       once all the workloads accessing this bucket are done | Retain |  |
-| `existingBucketID` _string_ | ExistingBucketID is the unique id of the bucket in the OSP. This field should be<br />used to specify a bucket that has been created outside of COSI.<br />This field will be empty when the Bucket is dynamically provisioned by COSI. |  |  |
+| `foo` _string_ | foo is an example field of Bucket. Edit bucket_types.go to remove/update |  |  |
 
 
 #### BucketStatus
 
 
 
-
+BucketStatus defines the observed state of Bucket.
 
 
 
 _Appears in:_
 - [Bucket](#bucket)
 
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `bucketReady` _boolean_ | BucketReady is a boolean condition to reflect the successful creation<br />of a bucket. |  |  |
-| `bucketID` _string_ | BucketID is the unique id of the bucket in the OSP. This field will be<br />populated by COSI. |  |  |
-
-
-#### DeletionPolicy
-
-_Underlying type:_ _string_
-
-
-
-
-
-_Appears in:_
-- [BucketClass](#bucketclass)
-- [BucketSpec](#bucketspec)
-
-| Field | Description |
-| --- | --- |
-| `Retain` |  |
-| `Delete` |  |
-
-
-#### Protocol
-
-_Underlying type:_ _string_
-
-
-
-
-
-_Appears in:_
-- [BucketAccessSpec](#bucketaccessspec)
-- [BucketClaimSpec](#bucketclaimspec)
-- [BucketSpec](#bucketspec)
-
-| Field | Description |
-| --- | --- |
-| `S3` |  |
-| `Azure` |  |
-| `GCP` |  |
 
 

--- a/docs/src/api/v1alpha1.md
+++ b/docs/src/api/v1alpha1.md
@@ -1,0 +1,288 @@
+# API Reference
+<!-- this file is no longer kept up-to-date by automatic generation scripts -->
+
+## Packages
+- [objectstorage.k8s.io/v1alpha1](#objectstoragek8siov1alpha1)
+
+
+## objectstorage.k8s.io/v1alpha1
+
+
+
+
+#### AuthenticationType
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [BucketAccessClass](#bucketaccessclass)
+
+| Field | Description |
+| --- | --- |
+| `Key` |  |
+| `IAM` |  |
+
+
+#### Bucket
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketList](#bucketlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[BucketSpec](#bucketspec)_ |  |  |  |
+| `status` _[BucketStatus](#bucketstatus)_ |  |  |  |
+
+
+#### BucketAccess
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketAccessList](#bucketaccesslist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[BucketAccessSpec](#bucketaccessspec)_ |  |  |  |
+| `status` _[BucketAccessStatus](#bucketaccessstatus)_ |  |  |  |
+
+
+#### BucketAccessClass
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketAccessClassList](#bucketaccessclasslist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `driverName` _string_ | DriverName is the name of driver associated with<br />this BucketAccess |  |  |
+| `authenticationType` _[AuthenticationType](#authenticationtype)_ | AuthenticationType denotes the style of authentication<br />It can be one of<br />Key - access, secret tokens based authentication<br />IAM - implicit authentication of pods to the OSP based on service account mappings |  |  |
+| `parameters` _object (keys:string, values:string)_ | Parameters is an opaque map for passing in configuration to a driver<br />for granting access to a bucket |  |  |
+
+
+
+
+
+
+#### BucketAccessSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketAccess](#bucketaccess)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `bucketClaimName` _string_ | BucketClaimName is the name of the BucketClaim. |  |  |
+| `protocol` _[Protocol](#protocol)_ | Protocol is the name of the Protocol<br />that this access credential is supposed to support<br />If left empty, it will choose the protocol supported<br />by the bucket. If the bucket supports multiple protocols,<br />the end protocol is determined by the driver. |  |  |
+| `bucketAccessClassName` _string_ | BucketAccessClassName is the name of the BucketAccessClass |  |  |
+| `credentialsSecretName` _string_ | CredentialsSecretName is the name of the secret that COSI should populate<br />with the credentials. If a secret by this name already exists, then it is<br />assumed that credentials have already been generated. It is not overridden.<br />This secret is deleted when the BucketAccess is delted. |  |  |
+| `serviceAccountName` _string_ | ServiceAccountName is the name of the serviceAccount that COSI will map<br />to the OSP service account when IAM styled authentication is specified |  |  |
+
+
+#### BucketAccessStatus
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketAccess](#bucketaccess)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `accountID` _string_ | AccountID is the unique ID for the account in the OSP. It will be populated<br />by the COSI sidecar once access has been successfully granted. |  |  |
+| `accessGranted` _boolean_ | AccessGranted indicates the successful grant of privileges to access the bucket |  |  |
+
+
+#### BucketClaim
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketClaimList](#bucketclaimlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[BucketClaimSpec](#bucketclaimspec)_ |  |  |  |
+| `status` _[BucketClaimStatus](#bucketclaimstatus)_ |  |  |  |
+
+
+
+
+#### BucketClaimSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketClaim](#bucketclaim)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `bucketClassName` _string_ | Name of the BucketClass |  |  |
+| `protocols` _[Protocol](#protocol) array_ | Protocols are the set of data API this bucket is required to support.<br />The possible values for protocol are:<br />-  S3: Indicates Amazon S3 protocol<br />-  Azure: Indicates Microsoft Azure BlobStore protocol<br />-  GCS: Indicates Google Cloud Storage protocol |  |  |
+| `existingBucketName` _string_ | Name of a bucket object that was manually<br />created to import a bucket created outside of COSI<br />If unspecified, then a new Bucket will be dynamically provisioned |  |  |
+
+
+#### BucketClaimStatus
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketClaim](#bucketclaim)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `bucketReady` _boolean_ | BucketReady indicates that the bucket is ready for consumpotion<br />by workloads |  |  |
+| `bucketName` _string_ | BucketName is the name of the provisioned Bucket in response<br />to this BucketClaim. It is generated and set by the COSI controller<br />before making the creation request to the OSP backend. |  |  |
+
+
+#### BucketClass
+
+
+
+
+
+
+
+_Appears in:_
+- [BucketClassList](#bucketclasslist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `driverName` _string_ | DriverName is the name of driver associated with this bucket |  |  |
+| `deletionPolicy` _[DeletionPolicy](#deletionpolicy)_ | DeletionPolicy is used to specify how COSI should handle deletion of this<br />bucket. There are 2 possible values:<br /> - Retain: Indicates that the bucket should not be deleted from the OSP<br /> - Delete: Indicates that the bucket should be deleted from the OSP<br />       once all the workloads accessing this bucket are done | Retain |  |
+| `parameters` _object (keys:string, values:string)_ | Parameters is an opaque map for passing in configuration to a driver<br />for creating the bucket |  |  |
+
+
+
+
+
+
+#### BucketSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [Bucket](#bucket)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `driverName` _string_ | DriverName is the name of driver associated with this bucket |  |  |
+| `bucketClassName` _string_ | Name of the BucketClass specified in the BucketRequest |  |  |
+| `bucketClaim` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core)_ | Name of the BucketClaim that resulted in the creation of this Bucket<br />In case the Bucket object was created manually, then this should refer<br />to the BucketClaim with which this Bucket should be bound |  |  |
+| `protocols` _[Protocol](#protocol) array_ | Protocols are the set of data APIs this bucket is expected to support.<br />The possible values for protocol are:<br />-  S3: Indicates Amazon S3 protocol<br />-  Azure: Indicates Microsoft Azure BlobStore protocol<br />-  GCS: Indicates Google Cloud Storage protocol |  |  |
+| `parameters` _object (keys:string, values:string)_ |  |  |  |
+| `deletionPolicy` _[DeletionPolicy](#deletionpolicy)_ | DeletionPolicy is used to specify how COSI should handle deletion of this<br />bucket. There are 2 possible values:<br /> - Retain: Indicates that the bucket should not be deleted from the OSP (default)<br /> - Delete: Indicates that the bucket should be deleted from the OSP<br />       once all the workloads accessing this bucket are done | Retain |  |
+| `existingBucketID` _string_ | ExistingBucketID is the unique id of the bucket in the OSP. This field should be<br />used to specify a bucket that has been created outside of COSI.<br />This field will be empty when the Bucket is dynamically provisioned by COSI. |  |  |
+
+
+#### BucketStatus
+
+
+
+
+
+
+
+_Appears in:_
+- [Bucket](#bucket)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `bucketReady` _boolean_ | BucketReady is a boolean condition to reflect the successful creation<br />of a bucket. |  |  |
+| `bucketID` _string_ | BucketID is the unique id of the bucket in the OSP. This field will be<br />populated by COSI. |  |  |
+
+
+#### DeletionPolicy
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [BucketClass](#bucketclass)
+- [BucketSpec](#bucketspec)
+
+| Field | Description |
+| --- | --- |
+| `Retain` |  |
+| `Delete` |  |
+
+
+#### Protocol
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [BucketAccessSpec](#bucketaccessspec)
+- [BucketClaimSpec](#bucketclaimspec)
+- [BucketSpec](#bucketspec)
+
+| Field | Description |
+| --- | --- |
+| `S3` |  |
+| `Azure` |  |
+| `GCP` |  |

--- a/docs/theme/index-template.hbs
+++ b/docs/theme/index-template.hbs
@@ -189,9 +189,6 @@
                     });
                 </script>
 
-<div id="version" class="version">
-  VERSION-PLACEHOLDER
-</div>
                 <div id="content" class="content">
                     <main>
                         {{{ content }}}


### PR DESCRIPTION
Allow COSI to generate docs for the WIP v1alpha2 API without overwriting v1alpha1 documentation. Copy the old v1alpha1 docs to a new file that is no longer kept up-to-date by autogen scripts. `out.md` is now generated for v1alpha2 docs, and both versions are linked on the doc page sidebar.