### PR TITLE
 update makefile help and docs for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
 ## Developer Guide
 
-Before contributing a Pull Request, ensure a [GitHub
-issue](https://github.com/kubernetes-sigs/container-object-storage-interface/issues) exists corresponding to the change.
-
 All API definitions and behavior must follow the [`v1alpha2` KEP PR](https://github.com/kubernetes/enhancements/pull/4599).
 Minor deviation from the KEP is acceptable in order to fix bugs.
 
@@ -45,6 +42,5 @@ Minor deviation from the KEP is acceptable in order to fix bugs.
 Changes may break compatibility up until `v1alpha2` is released with a semver tag.
 After the first `v1alpha2` semver release (e.g., 0.3.0), all changes must be backwards compatible.
 
-### Build and Test
-
-See `make help` for assistance
+Before making a COSI contribution, please read and follow the
+[core developer guide](https://container-object-storage-interface.sigs.k8s.io/developing/core.html).

--- a/client/config/crd/kustomization.yaml
+++ b/client/config/crd/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - objectstorage.k8s.io_bucketaccessclasses.yaml
+  - objectstorage.k8s.io_bucketaccesses.yaml
+  - objectstorage.k8s.io_bucketclaims.yaml
+  - objectstorage.k8s.io_bucketclasses.yaml
+  - objectstorage.k8s.io_buckets.yaml

--- a/controller/resources/deployment.yaml
+++ b/controller/resources/deployment.yaml
@@ -23,5 +23,4 @@ spec:
       containers:
         - name: objectstorage-controller
           image: gcr.io/k8s-staging-sig-storage/objectstorage-controller:v20251003-controllerv0.2.0-rc1-145-ge3bc25e
-          args:
-            - "--v=5"
+          args: []

--- a/docs/src/developing/core.md
+++ b/docs/src/developing/core.md
@@ -4,4 +4,26 @@ With “core” COSI we refer to the common set of API and controllers that are 
 
 Before your first contribution, you should follow [the Kubernetes Contributor Guide](https://www.kubernetes.dev/docs/guide/#contributor-guide).
 
-To further understand the COSI architecture, please refer to [KEP-1979: Object Storage Support](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1979-object-storage-support).
+To further understand the COSI architecture, please refer to [KEP-1979: Object Storage
+Support](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1979-object-storage-support).
+
+Before contributing a Pull Request, ensure a [GitHub issue](https://github.com/kubernetes-sigs/container-object-storage-interface/issues) exists corresponding to the change.
+
+## Local code development
+
+For new contributors, use `make help`, and use **Core** targets as needed.
+These targets ensure changes build successfully, pass basic checks, and are ready for end-to-end tests run in COSI's automated CI.
+
+Other more advanced targets are available and also described in `make help` output.
+
+Some specific workflows are documented below.
+
+### Building and deploying COSI controller changes locally
+
+```sh
+export CONTROLLER_TAG="$MY_REPO"/cosi-controller:latest # replace MY_REPO with desired dev repo
+make -j prebuild
+make build.controller
+docker push "$CONTROLLER_TAG"
+make deploy
+```

--- a/hack/dev-kustomize.sh
+++ b/hack/dev-kustomize.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o xtrace
+
+#
+# generate a kustomization file for local development use
+# use the Makefile's CONTROLLER_TAG as the image used for dev deployment
+#
+
+# store generated file(s) in cache dir not checked into git
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT="$SCRIPT_DIR"/..
+CACHE_DIR="$ROOT"/.cache
+mkdir -p "$CACHE_DIR"
+
+# copy root kustomization.yaml file to cache dir, and...
+# replace './' in root kustomization.yaml with '../' for usage from cache dir
+DEV_KUSTOMIZE_FILE="$CACHE_DIR"/kustomization.yaml
+sed -e 's|\./|../|g' "$ROOT"/kustomization.yaml > "$DEV_KUSTOMIZE_FILE"
+
+# process Makefile's CONTROLLER_TAG into name and tag components
+#   e.g., CONTROLLER_TAG="localhost:5000/cosi-controller:latest"
+NEW_NAME="${CONTROLLER_TAG%:*}" # e.g., "localhost:5000/cosi-controller"
+NEW_TAG="${CONTROLLER_TAG##*:}" # e.g., "latest"
+
+# replace the default controller image with one for local dev
+cat <<EOF >> "$DEV_KUSTOMIZE_FILE"
+
+images:
+  - name: gcr.io/k8s-staging-sig-storage/objectstorage-controller
+    newName: "$NEW_NAME"
+    newTag: "$NEW_TAG"
+EOF

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -9,9 +9,6 @@ commonAnnotations:
   api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1979-object-storage-support
 
 resources:
-  - client/config/crd/objectstorage.k8s.io_bucketaccesses.yaml
-  - client/config/crd/objectstorage.k8s.io_bucketaccessclasses.yaml
-  - client/config/crd/objectstorage.k8s.io_bucketclasses.yaml
-  - client/config/crd/objectstorage.k8s.io_bucketclaims.yaml
-  - client/config/crd/objectstorage.k8s.io_buckets.yaml
-  - controller
+  # ensure all resources begin with './'
+  - ./client/config/crd
+  - ./controller

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 # Netlify build instructions
 [build]
-    command = "make build-docs"
+    command = "make docs"
     publish = "docs/book"
 
 [build.environment]


### PR DESCRIPTION
    Rearrange make targets to separate basic from advanced targets. Add some
    more developer documentation to help new contributors.
    
    Modify 'make deploy' for easier local development. Modify Kustomize
    resource definitions to make it easier to create a local-specific
    kustomize.yaml file for an individual development environment.
    Add a script to help deploy a locally-built COSI controller without risk
    of accidentally committing changes to git.
    
    Add local controller dev workflow to developer doc.


New `make help` output:

<img width="771" height="632" alt="image" src="https://github.com/user-attachments/assets/9dd8d7f0-ba93-4734-9c6d-55ab9edb8c2a" />

Note that some values from the screenshot are showing my local env var overrides, like `DOCKER ("podman")` instead of  the default `DOCKER ("docker")`.
