### PR TITLE
Cleanup: replace custom contains() with slices.Contains()

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -73,14 +73,3 @@ type RpcApiTranslator[RpcType any, ApiType comparable] interface {
 	// Validate checks that user-domain API fields meet requirements and expectations.
 	Validate(map[ApiType]string, cosiapi.BucketAccessAuthenticationType) error
 }
-
-// contains is a helper that returns true if the given `list` contains the item `key`.
-// Useful for a variety of Validate() implementations.
-func contains[T comparable](list []T, key T) bool {
-	for _, i := range list {
-		if i == key {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/protocol/s3.go
+++ b/internal/protocol/s3.go
@@ -18,6 +18,7 @@ package protocol
 
 import (
 	"fmt"
+	"slices"
 
 	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
 	cosiproto "sigs.k8s.io/container-object-storage-interface/proto"
@@ -111,7 +112,7 @@ func (S3BucketInfoTranslator) Validate(
 	}
 
 	as := vars[cosiapi.BucketInfoVar_S3_AddressingStyle]
-	if !contains(validS3AddressingStyles, as) {
+	if !slices.Contains(validS3AddressingStyles, as) {
 		errs = append(errs, fmt.Sprintf("S3 addressing style %q must be one of %v", as, validS3AddressingStyles))
 	}
 

--- a/sidecar/internal/reconciler/bucket.go
+++ b/sidecar/internal/reconciler/bucket.go
@@ -19,6 +19,7 @@ package reconciler
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -366,7 +367,7 @@ func validateDriverSupportsProtocols(driver DriverInfo, required []*cosiproto.Ob
 func validateBucketSupportsProtocols(supported, required []cosiapi.ObjectProtocol) error {
 	unsupported := []string{}
 	for _, req := range required {
-		if !contains(supported, req) {
+		if !slices.Contains(supported, req) {
 			unsupported = append(unsupported, string(req))
 		}
 	}
@@ -385,14 +386,4 @@ func mergeApiInfoIntoStringMap[T cosiapi.BucketInfoVar | cosiapi.CredentialVar](
 	for k, v := range varKey {
 		target[string(k)] = v
 	}
-}
-
-// contains returns true if the given `list` contains the item `key`.
-func contains[T comparable](list []T, key T) bool {
-	for _, i := range list {
-		if i == key {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Description
This PR removes duplicate `contains[T comparable]()` implementations and uses the standard library `slices.Contains()` function instead.

## Changes
- Removed `contains[T comparable]()` from `internal/protocol/protocol.go`
- Removed `contains[T comparable]()` from `sidecar/internal/reconciler/bucket.go`
- Replaced `contains()` usage in `internal/protocol/s3.go` with `slices.Contains()`
- Replaced `contains()` usage in `sidecar/internal/reconciler/bucket.go` with `slices.Contains()`

## Testing
- Verified that all code compiles successfully with `go build ./...`
- No test changes needed as this is a simple refactoring

Fixes #176