### PR TITLE
Add missing DriverInfo field to BucketReconciler initialization

### DIFF
--- a/sidecar/cmd/main.go
+++ b/sidecar/cmd/main.go
@@ -164,8 +164,9 @@ func main() {
 	}
 
 	if err := (&reconciler.BucketReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		DriverInfo: *driverInfo,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "Bucket")
 		os.Exit(1)


### PR DESCRIPTION
https://github.com/kubernetes-sigs/container-object-storage-interface/issues/324

Populate DriverInfo in BucketReconciler.
To prevent nil pointer when calling gRPC provisioner client.