### PR TITLE
Refactor: use errors.Join for multi-error returns

### DIFF
--- a/internal/protocol/azure.go
+++ b/internal/protocol/azure.go
@@ -17,6 +17,7 @@ limitations under the License.
 package protocol
 
 import (
+	"errors"
 	"fmt"
 
 	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
@@ -60,15 +61,15 @@ func (AzureBucketInfoTranslator) ApiToRpc(vars map[cosiapi.BucketInfoVar]string)
 func (AzureBucketInfoTranslator) Validate(
 	vars map[cosiapi.BucketInfoVar]string, _ cosiapi.BucketAccessAuthenticationType,
 ) error {
-	errs := []string{}
+	errs := []error{}
 
 	storageAccount := vars[cosiapi.BucketInfoVar_Azure_StorageAccount]
 	if storageAccount == "" {
-		errs = append(errs, "azure storage account cannot be unset")
+		errs = append(errs, fmt.Errorf("azure storage account cannot be unset"))
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("azure bucket info is invalid: %v", errs)
+		return fmt.Errorf("azure bucket info is invalid: %w", errors.Join(errs...))
 	}
 	return nil
 }
@@ -107,15 +108,15 @@ func (AzureCredentialTranslator) Validate(
 		return nil
 	}
 
-	errs := []string{}
+	errs := []error{}
 
 	accessToken := vars[cosiapi.CredentialVar_Azure_AccessToken]
 	if accessToken == "" {
-		errs = append(errs, "azure access token cannot be unset")
+		errs = append(errs, fmt.Errorf("azure access token cannot be unset"))
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("azure credential info is invalid: %v", errs)
+		return fmt.Errorf("azure credential info is invalid: %w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/internal/protocol/gcs.go
+++ b/internal/protocol/gcs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package protocol
 
 import (
+	"errors"
 	"fmt"
 
 	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
@@ -62,20 +63,20 @@ func (GcsBucketInfoTranslator) ApiToRpc(vars map[cosiapi.BucketInfoVar]string) *
 func (GcsBucketInfoTranslator) Validate(
 	vars map[cosiapi.BucketInfoVar]string, _ cosiapi.BucketAccessAuthenticationType,
 ) error {
-	errs := []string{}
+	errs := []error{}
 
 	bucketName := vars[cosiapi.BucketInfoVar_GCS_BucketName]
 	if bucketName == "" {
-		errs = append(errs, "GCS bucket name cannot be unset")
+		errs = append(errs, fmt.Errorf("GCS bucket name cannot be unset"))
 	}
 
 	projectId := vars[cosiapi.BucketInfoVar_GCS_ProjectId]
 	if projectId == "" {
-		errs = append(errs, "GCS project ID cannot be unset")
+		errs = append(errs, fmt.Errorf("GCS project ID cannot be unset"))
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("GCS bucket info is invalid: %v", errs)
+		return fmt.Errorf("GCS bucket info is invalid: %w", errors.Join(errs...))
 	}
 	return nil
 }
@@ -113,34 +114,34 @@ func (GcsCredentialTranslator) ApiToRpc(vars map[cosiapi.CredentialVar]string) *
 func (GcsCredentialTranslator) Validate(
 	vars map[cosiapi.CredentialVar]string, authType cosiapi.BucketAccessAuthenticationType,
 ) error {
-	errs := []string{}
+	errs := []error{}
 
 	switch authType {
 	case cosiapi.BucketAccessAuthenticationTypeKey:
 		accessId := vars[cosiapi.CredentialVar_GCS_AccessId]
 		if accessId == "" {
-			errs = append(errs, "GCS access ID cannot be unset")
+			errs = append(errs, fmt.Errorf("GCS access ID cannot be unset"))
 		}
 
 		accessSecret := vars[cosiapi.CredentialVar_GCS_AccessSecret]
 		if accessSecret == "" {
-			errs = append(errs, "GCS access secret cannot be unset")
+			errs = append(errs, fmt.Errorf("GCS access secret cannot be unset"))
 		}
 
 	case cosiapi.BucketAccessAuthenticationTypeServiceAccount:
 		privateKeyName := vars[cosiapi.CredentialVar_GCS_PrivateKeyName]
 		if privateKeyName == "" {
-			errs = append(errs, "GCS private key name cannot be unset")
+			errs = append(errs, fmt.Errorf("GCS private key name cannot be unset"))
 		}
 
 		serviceAccount := vars[cosiapi.CredentialVar_GCS_ServiceAccount]
 		if serviceAccount == "" {
-			errs = append(errs, "GCS service account cannot be unset")
+			errs = append(errs, fmt.Errorf("GCS service account cannot be unset"))
 		}
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("GCS credential info is invalid: %v", errs)
+		return fmt.Errorf("GCS credential info is invalid: %w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/internal/protocol/s3.go
+++ b/internal/protocol/s3.go
@@ -17,6 +17,7 @@ limitations under the License.
 package protocol
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -97,30 +98,30 @@ func (S3BucketInfoTranslator) ApiToRpc(vars map[cosiapi.BucketInfoVar]string) *c
 func (S3BucketInfoTranslator) Validate(
 	vars map[cosiapi.BucketInfoVar]string, _ cosiapi.BucketAccessAuthenticationType,
 ) error {
-	errs := []string{}
+	errs := []error{}
 
 	id := vars[cosiapi.BucketInfoVar_S3_BucketId]
 	if id == "" {
-		errs = append(errs, "S3 bucket ID cannot be unset")
+		errs = append(errs, fmt.Errorf("S3 bucket ID cannot be unset"))
 	}
 
 	ep := vars[cosiapi.BucketInfoVar_S3_Endpoint]
 	if ep == "" {
-		errs = append(errs, "S3 endpoint cannot be unset")
+		errs = append(errs, fmt.Errorf("S3 endpoint cannot be unset"))
 	}
 
 	rg := vars[cosiapi.BucketInfoVar_S3_Region]
 	if rg == "" {
-		errs = append(errs, "S3 region cannot be unset")
+		errs = append(errs, fmt.Errorf("S3 region cannot be unset"))
 	}
 
 	as := vars[cosiapi.BucketInfoVar_S3_AddressingStyle]
 	if !slices.Contains(validS3AddressingStyles, as) {
-		errs = append(errs, fmt.Sprintf("S3 addressing style %q must be one of %v", as, validS3AddressingStyles))
+		errs = append(errs, fmt.Errorf("S3 addressing style %q must be one of %v", as, validS3AddressingStyles))
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("S3 bucket info is invalid: %v", errs)
+		return fmt.Errorf("S3 bucket info is invalid: %w", errors.Join(errs...))
 	}
 	return nil
 }
@@ -159,20 +160,20 @@ func (S3CredentialTranslator) Validate(
 		return nil
 	}
 
-	errs := []string{}
+	errs := []error{}
 
 	accessKeyId := vars[cosiapi.CredentialVar_S3_AccessKeyId]
 	if accessKeyId == "" {
-		errs = append(errs, "S3 access key ID cannot be unset")
+		errs = append(errs, fmt.Errorf("S3 access key ID cannot be unset"))
 	}
 
 	accessSecretKey := vars[cosiapi.CredentialVar_S3_AccessSecretKey]
 	if accessSecretKey == "" {
-		errs = append(errs, "S3 access secret key cannot be unset")
+		errs = append(errs, fmt.Errorf("S3 access secret key cannot be unset"))
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("S3 credential info is invalid: %v", errs)
+		return fmt.Errorf("S3 credential info is invalid: %w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/sidecar/internal/reconciler/bucket.go
+++ b/sidecar/internal/reconciler/bucket.go
@@ -317,13 +317,13 @@ func parseProtocolBucketInfo(pbi *cosiproto.ObjectProtocolAndBucketInfo) (
 
 // convert an API proto list into an RPC proto message list
 func objectProtocolListFromApiList(apiList []cosiapi.ObjectProtocol) ([]*cosiproto.ObjectProtocol, error) {
-	errs := []string{}
+	errs := []error{}
 	out := []*cosiproto.ObjectProtocol{}
 
 	for _, apiProto := range apiList {
 		rpcProto, err := protocol.ObjectProtocolTranslator{}.ApiToRpc(apiProto)
 		if err != nil {
-			errs = append(errs, err.Error())
+			errs = append(errs, err)
 			continue
 		}
 		out = append(out, &cosiproto.ObjectProtocol{
@@ -332,7 +332,7 @@ func objectProtocolListFromApiList(apiList []cosiapi.ObjectProtocol) ([]*cosipro
 	}
 
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("failed to parse protocol list: %v", errs)
+		return nil, fmt.Errorf("failed to parse protocol list: %w", errors.Join(errs...))
 	}
 	return out, nil
 }
@@ -362,7 +362,7 @@ func validateBucketSupportsProtocols(supported, required []cosiapi.ObjectProtoco
 		}
 	}
 	if len(unsupported) > 0 {
-		return fmt.Errorf("required protocols are not supported: %v", required)
+		return fmt.Errorf("required protocols are not supported: %v", unsupported)
 	}
 	return nil
 }


### PR DESCRIPTION
What this PR does 

This PR updates places in the codebase where multiple errors were being combined using fmt.Errorf("...: %v", errs).
They now use errors.Join(errs...) instead.

errors.Join keeps the original error types intact and allows unwrapping, while the previous formatting approach was losing that context.

**Issue fixed**

- Fixes #191

**Notes for the reviewer**

Files/areas touched in this refactor:

1. Controller: bucketaccess.go

2. Sidecar: bucket.go

3. Internal protocol: s3.go, azure.go, gcs.go

**Verification**

Checked that the Validate methods now return joined errors instead of formatted slices.

All existing tests passed after the change.