### PR TITLE
Fix flaky gRPC tests in sidecar 

### DIFF
--- a/sidecar/internal/test/rpc.go
+++ b/sidecar/internal/test/rpc.go
@@ -89,5 +89,9 @@ func ClientConn(tmpSockUri string) (*grpc.ClientConn, error) {
 	return grpc.NewClient(tmpSockUri,
 		// nothing fancy for unit tests
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			// Handle server starting slower than client calls in tests
+			grpc.WaitForReady(true),
+		),
 	)
 }


### PR DESCRIPTION
## Summary

Fixes flaky gRPC tests in sidecar reconciler by adding `grpc.WaitForReady(true)` to test client connections.

## Problem

Tests in `sidecar/internal/reconciler/bucket_test.go` fail intermittently when the gRPC client connects before the test server is ready.

## Solution

Add `grpc.WaitForReady(true)` option to test client setup in `sidecar/internal/test/rpc.go` to wait for server readiness before sending
RPCs.

## How to Verify

To reproduce the issue, run the tests via docker in main branch:

```bash
[~/tmp/k8s/container-object-storage-interface]
git checkout main
Already on 'main'
Your branch is up to date with 'origin/main'.
[~/tmp/k8s/container-object-storage-interface]
docker run --rm -v "$PWD:/workspace" -w /workspace golang:1.24 make test
make -C proto check
make[1]: Entering directory '/workspace/proto'
make[1]: Nothing to be done for 'check'.
make[1]: Leaving directory '/workspace/proto'
cd client && go fmt ./...
go: downloading k8s.io/apimachinery v0.34.2
...
cd client && go vet ./...
cd client && go test ./...
?   	sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2	[no test files]
cd controller && go fmt ./...
cd controller && go vet ./...
cd controller && go test ./...
?   	sigs.k8s.io/container-object-storage-interface/controller/cmd	[no test files]
ok  	sigs.k8s.io/container-object-storage-interface/controller/internal/reconciler	0.072s
cd sidecar && go fmt ./...
cd sidecar && go vet ./...
cd sidecar && go test ./...
ok  	sigs.k8s.io/container-object-storage-interface/sidecar/cmd	0.632s
panic: grpc: the server has been stopped

goroutine 149 [running]:
sigs.k8s.io/container-object-storage-interface/sidecar/internal/test.Server.func6()
	/workspace/sidecar/internal/test/rpc.go:80 +0x70
created by sigs.k8s.io/container-object-storage-interface/sidecar/internal/reconciler.TestBucketReconciler_dynamicProvision.func4 in goroutine 148
	/workspace/sidecar/internal/reconciler/bucket_test.go:663 +0xa0
FAIL	sigs.k8s.io/container-object-storage-interface/sidecar/internal/reconciler	0.074s
?   	sigs.k8s.io/container-object-storage-interface/sidecar/internal/test	[no test files]
FAIL
make: *** [Makefile:75: test.sidecar] Error 1
```

Verify the by running the same command in the PR branch:

TURNS OUT THE CURRENT UPDATE DOESN'T RESOLVE THE ISSUE. FURTHER DEVELOPMENT IS IN PROGRESS. 