### PR TITLE
add test helper to bootstrap new unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,9 @@ golangci-lint-fix.%: golangci-lint
 	cd $* && $(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml --new --fix
 
 .PHONY: test
-test: .test.proto test.client test.controller test.sidecar ## Run all unit tests including vet and fmt
-test.%: fmt.% vet.% FORCE
-	cd $* && go test ./...
+test: .test.proto vet .test.go ## Run all unit tests including vet and fmt
+.test.go: fmt
+	go test -v -cover ./...
 .PHONY: .test.proto
 .test.proto: # gRPC proto has a special unit test
 	$(MAKE) -C proto check
@@ -126,14 +126,12 @@ codegen.proto:
 	$(MAKE) -C proto codegen
 
 .PHONY: fmt
-fmt: fmt.client fmt.controller fmt.sidecar
-fmt.%: FORCE
-	cd $* && go fmt ./...
+fmt:
+	go fmt ./...
 
 .PHONY: vet
-vet: vet.client vet.controller vet.sidecar
-vet.%: FORCE
-	cd $* && go vet ./...
+vet:
+	go vet ./...
 
 .PHONY: docs
 docs: generate crd-ref-docs mdbook ## Build docs

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package test contains utilities for unit testing.
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
+)
+
+// Dependencies contains bootstrapped COSI unit test dependencies.
+type Dependencies struct {
+	ContextWithLogger context.Context // context containing the test logger
+	Client            client.Client   // test client containing bootstrapped objects
+	Logger            logr.Logger     // the test logger, for convenience
+}
+
+// MustBootstrap bootstraps new COSI unit test dependencies, or panics if an error occurs.
+func MustBootstrap(t *testing.T, initialClientObjects ...client.Object) *Dependencies {
+	logger := testr.NewWithOptions(t, testr.Options{
+		Verbosity: 1,
+	})
+	contextWithLogger := logr.NewContext(context.Background(), logger)
+
+	scheme := runtime.NewScheme()
+	err := cosiapi.AddToScheme(scheme)
+	if err != nil {
+		panic(err)
+	}
+	err = corev1.AddToScheme(scheme) // required for bucketaccess tests with secrets
+	if err != nil {
+		panic(err)
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initialClientObjects...).
+		WithStatusSubresource(
+			&cosiapi.Bucket{},
+			&cosiapi.BucketClaim{},
+			&cosiapi.BucketAccess{},
+		).
+		Build()
+
+	return &Dependencies{
+		ContextWithLogger: contextWithLogger,
+		Client:            client,
+		Logger:            logger,
+	}
+}

--- a/vendor/github.com/go-logr/logr/testr/testr.go
+++ b/vendor/github.com/go-logr/logr/testr/testr.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testr provides support for using logr in tests.
+package testr
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+)
+
+// New returns a logr.Logger that prints through a testing.T object.
+// Info logs are only enabled at V(0).
+func New(t *testing.T) logr.Logger {
+	return NewWithOptions(t, Options{})
+}
+
+// Options carries parameters which influence the way logs are generated.
+type Options struct {
+	// LogTimestamp tells the logger to add a "ts" key to log
+	// lines. This has some overhead, so some users might not want
+	// it.
+	LogTimestamp bool
+
+	// Verbosity tells the logger which V logs to be write.
+	// Higher values enable more logs.
+	Verbosity int
+}
+
+// NewWithOptions returns a logr.Logger that prints through a testing.T object.
+// In contrast to the simpler New, output formatting can be configured.
+func NewWithOptions(t *testing.T, opts Options) logr.Logger {
+	l := &testlogger{
+		testloggerInterface: newLoggerInterfaceWithOptions(t, opts),
+	}
+	return logr.New(l)
+}
+
+// TestingT is an interface wrapper around testing.T, testing.B and testing.F.
+type TestingT interface {
+	Helper()
+	Log(args ...any)
+}
+
+// NewWithInterface returns a logr.Logger that prints through a
+// TestingT object.
+// In contrast to the simpler New, output formatting can be configured.
+func NewWithInterface(t TestingT, opts Options) logr.Logger {
+	l := newLoggerInterfaceWithOptions(t, opts)
+	return logr.New(&l)
+}
+
+func newLoggerInterfaceWithOptions(t TestingT, opts Options) testloggerInterface {
+	return testloggerInterface{
+		t: t,
+		Formatter: funcr.NewFormatter(funcr.Options{
+			LogTimestamp: opts.LogTimestamp,
+			Verbosity:    opts.Verbosity,
+		}),
+	}
+}
+
+// Underlier exposes access to the underlying testing.T instance. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type Underlier interface {
+	GetUnderlying() *testing.T
+}
+
+// UnderlierInterface exposes access to the underlying TestingT instance. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type UnderlierInterface interface {
+	GetUnderlying() TestingT
+}
+
+// Info logging implementation shared between testLogger and testLoggerInterface.
+func logInfo(t TestingT, formatInfo func(int, string, []any) (string, string), level int, msg string, kvList ...any) {
+	prefix, args := formatInfo(level, msg, kvList)
+	t.Helper()
+	if prefix != "" {
+		args = prefix + ": " + args
+	}
+	t.Log(args)
+}
+
+// Error logging implementation shared between testLogger and testLoggerInterface.
+func logError(t TestingT, formatError func(error, string, []any) (string, string), err error, msg string, kvList ...any) {
+	prefix, args := formatError(err, msg, kvList)
+	t.Helper()
+	if prefix != "" {
+		args = prefix + ": " + args
+	}
+	t.Log(args)
+}
+
+// This type exists to wrap and modify the method-set of testloggerInterface.
+// In particular, it changes the GetUnderlying() method.
+type testlogger struct {
+	testloggerInterface
+}
+
+func (l testlogger) GetUnderlying() *testing.T {
+	// This method is defined on testlogger, so the only type this could
+	// possibly be is testing.T, even though that's not guaranteed by the type
+	// system itself.
+	return l.t.(*testing.T) //nolint:forcetypeassert
+}
+
+type testloggerInterface struct {
+	funcr.Formatter
+	t TestingT
+}
+
+func (l testloggerInterface) WithName(name string) logr.LogSink {
+	l.AddName(name) // via Formatter
+	return &l
+}
+
+func (l testloggerInterface) WithValues(kvList ...any) logr.LogSink {
+	l.AddValues(kvList) // via Formatter
+	return &l
+}
+
+func (l testloggerInterface) GetCallStackHelper() func() {
+	return l.t.Helper
+}
+
+func (l testloggerInterface) Info(level int, msg string, kvList ...any) {
+	l.t.Helper()
+	logInfo(l.t, l.FormatInfo, level, msg, kvList...)
+}
+
+func (l testloggerInterface) Error(err error, msg string, kvList ...any) {
+	l.t.Helper()
+	logError(l.t, l.FormatError, err, msg, kvList...)
+}
+
+func (l testloggerInterface) GetUnderlying() TestingT {
+	return l.t
+}
+
+// Assert conformance to the interfaces.
+var _ logr.LogSink = &testlogger{}
+var _ logr.CallStackHelperLogSink = &testlogger{}
+var _ Underlier = &testlogger{}
+
+var _ logr.LogSink = &testloggerInterface{}
+var _ logr.CallStackHelperLogSink = &testloggerInterface{}
+var _ UnderlierInterface = &testloggerInterface{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -42,6 +42,7 @@ github.com/fxamacker/cbor/v2
 github.com/go-logr/logr
 github.com/go-logr/logr/funcr
 github.com/go-logr/logr/slogr
+github.com/go-logr/logr/testr
 # github.com/go-logr/stdr v1.2.2
 ## explicit; go 1.16
 github.com/go-logr/stdr


### PR DESCRIPTION
Add a new test helper to bootstrap new unit test dependencies.

The bootstrapper sets up a new context that contains a logger that outputs all runtime logs to testing.T's logger to help with debugging unit tests in prow, as well as to allow manually observing how logs appear at runtime.

The bootstrapper sets up a new client with some given initial objects. Importantly, the client supports status resources for COSI's API types.

Because log visibility is an important part of the change, the
`make test` target is updated to run all tests with one invocation
rather than running client/controller/sidecar/internall tests in
separate invocations.

Resolves #175