### PR TITLE
clean up golangci-lint config and invocation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,16 +33,11 @@ linters:
   exclusions:
     generated: lax
     rules:
-      - linters:
-          - lll
-        path: apis/*
-      - linters:
-          - dupl
-          - lll
-        path: internal/*
-      - linters:
-          - goconst
-        path: _test.go
+      - path: _test.go
+        linters:
+          - goconst # tests often avoid constants for readability
+          - dupl # duplication is usually intended in tests
+          - lll # long lines usually acceptable in tests
 
 formatters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,9 @@ export
 all: prebuild build ## Build all container images, plus their prerequisites (faster with 'make -j')
 
 .PHONY: lint
-lint: golangci-lint.client golangci-lint.controller golangci-lint.sidecar kubeapi-lint spell-lint dockerfiles-lint ## Run all linters (suggest `make -k`)
-golangci-lint.%: golangci-lint
-	cd $* && $(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml --new
+lint: golangci-lint kubeapi-lint spell-lint dockerfiles-lint ## Run all linters (suggest `make -k`)
+golangci-lint: golangci-lint
+	$(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml
 kubeapi-lint: kube-api-linter
 	cd client/apis && $(KUBEAPI_LINT) run --config $(CURDIR)/client/.kubeapilint.yaml
 spell-lint:
@@ -67,9 +67,9 @@ dockerfiles-lint:
 	hack/tools/lint-dockerfiles.sh $(HADOLINT_VERSION)
 
 .PHONY: lint-fix
-lint-fix: golangci-lint-fix.client golangci-lint-fix.controller golangci-lint-fix.sidecar ## Run all linters and perform fixes where possible (suggest `make -k`)
-golangci-lint-fix.%: golangci-lint
-	cd $* && $(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml --new --fix
+lint-fix: golangci-lint-fix ## Run all linters and perform fixes where possible (suggest `make -k`)
+golangci-lint-fix: golangci-lint
+	$(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml --fix
 
 .PHONY: test
 test: .test.proto vet .test.go ## Run all unit tests including vet and fmt

--- a/controller/pkg/reconciler/bucketaccess.go
+++ b/controller/pkg/reconciler/bucketaccess.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
-	objectstoragev1alpha2 "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
 	"sigs.k8s.io/container-object-storage-interface/internal/bucketaccess"
 	cosierr "sigs.k8s.io/container-object-storage-interface/internal/errors"
 	cosipredicate "sigs.k8s.io/container-object-storage-interface/internal/predicate"
@@ -106,7 +105,7 @@ func (r *BucketAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // SetupWithManager sets up the controller with the Manager.
 func (r *BucketAccessReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&objectstoragev1alpha2.BucketAccess{}).
+		For(&cosiapi.BucketAccess{}).
 		Named("bucketaccess").
 		WithEventFilter(
 			ctrlpredicate.And(
@@ -209,7 +208,8 @@ func (r *BucketAccessReconciler) reconcile(
 	blockers := cannotAccessBucketClaims(claimsByName, access.Spec)
 	if len(blockers) > 0 {
 		logger.Error(nil, "access cannot be provisioned for one or more BucketClaims", "blockers", blockers)
-		return cosierr.NonRetryableError(fmt.Errorf("access cannot be provisioned for one or more BucketClaims: %v", blockers))
+		return cosierr.NonRetryableError(
+			fmt.Errorf("access cannot be provisioned for one or more BucketClaims: %v", blockers))
 	}
 
 	waitlist := waitingOnBucketClaims(claimsByName)
@@ -320,7 +320,8 @@ func markAllBucketClaimsAsAccessed(
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to mark one or more BucketClaims as having a BucketAccess reference: %w", errors.Join(errs...))
+		return fmt.Errorf("failed to mark one or more BucketClaims as having a BucketAccess reference: %w",
+			errors.Join(errs...))
 	}
 
 	return nil

--- a/internal/protocol/azure.go
+++ b/internal/protocol/azure.go
@@ -113,7 +113,7 @@ func (AzureCredentialTranslator) ApiToRpc(vars map[cosiapi.CredentialVar]string)
 func (AzureCredentialTranslator) Validate(
 	vars map[cosiapi.CredentialVar]string, authType cosiapi.BucketAccessAuthenticationType,
 ) error {
-	//credentials are only required when authentication type is "Key"
+	// credentials are only required when authentication type is "Key"
 	if authType != cosiapi.BucketAccessAuthenticationTypeKey {
 		return nil
 	}


### PR DESCRIPTION
The golangci-lint config that was auto-translated from v1 to v2 seems to have had some issues in translation. There was also an issue that golangci-lint wasn't being run against `./internal` code.

Fix golangci-lint config, and ensure codebase is updated to resolve existing golangci-lint issues that have been missed.

This overlaps some with #223