### PR TITLE
add BucketID to BucketAccess accessed bucket tracking

### DIFF
--- a/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
+++ b/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
@@ -215,6 +215,16 @@ type AccessedBucket struct {
 	// +kubebuilder:validation:XValidation:message="name must be a valid resource name",rule="!format.dns1123Subdomain().validate(self).hasValue()"
 	BucketName string `json:"bucketName,omitempty"`
 
+	// bucketID is the unique identifier for the backend bucket known to the driver for which
+	// this access should have permissions.
+	// Must be at most 2048 characters and consist only of alphanumeric characters ([a-z0-9A-Z]),
+	// dashes (-), dots (.), underscores (_), and forward slash (/).
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=2048
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9/._-]+$`
+	BucketID string `json:"bucketID,omitempty"`
+
 	// bucketClaimName must match a BucketClaimAccess's BucketClaimName from the spec.
 	// Must be a valid Kubernetes resource name: at most 253 characters, consisting only of
 	// lower-case alphanumeric characters, hyphens, and periods, starting and ending with an

--- a/client/config/crd/objectstorage.k8s.io_bucketaccesses.yaml
+++ b/client/config/crd/objectstorage.k8s.io_bucketaccesses.yaml
@@ -179,6 +179,16 @@ spec:
                       x-kubernetes-validations:
                       - message: name must be a valid resource name
                         rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                    bucketID:
+                      description: |-
+                        bucketID is the unique identifier for the backend bucket known to the driver for which
+                        this access should have permissions.
+                        Must be at most 2048 characters and consist only of alphanumeric characters ([a-z0-9A-Z]),
+                        dashes (-), dots (.), underscores (_), and forward slash (/).
+                      maxLength: 2048
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9/._-]+$
+                      type: string
                     bucketName:
                       description: |-
                         bucketName is the name of a Bucket the access should have permissions for.
@@ -193,6 +203,7 @@ spec:
                         rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                   required:
                   - bucketClaimName
+                  - bucketID
                   - bucketName
                   type: object
                 maxItems: 128

--- a/docs/src/api/out.md
+++ b/docs/src/api/out.md
@@ -36,6 +36,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `bucketName` _string_ | bucketName is the name of a Bucket the access should have permissions for.<br />Must be a valid Kubernetes resource name: at most 253 characters, consisting only of<br />lower-case alphanumeric characters, hyphens, and periods, starting and ending with an<br />alphanumeric character. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
+| `bucketID` _string_ | bucketID is the unique identifier for the backend bucket known to the driver for which<br />this access should have permissions.<br />Must be at most 2048 characters and consist only of alphanumeric characters ([a-z0-9A-Z]),<br />dashes (-), dots (.), underscores (_), and forward slash (/). |  | MaxLength: 2048 <br />MinLength: 1 <br />Pattern: `^[a-zA-Z0-9/._-]+$` <br /> |
 | `bucketClaimName` _string_ | bucketClaimName must match a BucketClaimAccess's BucketClaimName from the spec.<br />Must be a valid Kubernetes resource name: at most 253 characters, consisting only of<br />lower-case alphanumeric characters, hyphens, and periods, starting and ending with an<br />alphanumeric character. |  | MaxLength: 253 <br />MinLength: 1 <br /> |
 
 

--- a/internal/test/controller/test.go
+++ b/internal/test/controller/test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller contains utilities for unit testing that help approximate COSI Controller
+// behaviors.
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
+	controller "sigs.k8s.io/container-object-storage-interface/controller/pkg/reconciler"
+	cositest "sigs.k8s.io/container-object-storage-interface/internal/test"
+)
+
+// ReconcileBucketClaim reconciles the BucketClaim with the given namespaced name for unit tests.
+// BucketClaim should exist (if desired) in the bootstrapped dependencies's client.
+func ReconcileBucketClaim(
+	t *testing.T,
+	bootstrapped *cositest.Dependencies,
+	nsName types.NamespacedName,
+) (*cosiapi.BucketClaim, error) {
+	r := controller.BucketClaimReconciler{
+		Client: bootstrapped.Client,
+		Scheme: bootstrapped.Client.Scheme(),
+	}
+
+	_, err := r.Reconcile(bootstrapped.ContextWithLogger, ctrl.Request{NamespacedName: nsName})
+	if err != nil {
+		if err.Error() != "waiting for Bucket to be provisioned" {
+			// to make tests consuming this easier, only return an error if it's not the one we
+			// (currently) expect after a successful reconcile
+			return nil, err
+		}
+	}
+
+	claim := &cosiapi.BucketClaim{}
+	if err := bootstrapped.Client.Get(bootstrapped.ContextWithLogger, nsName, claim); err != nil {
+		return nil, err
+	}
+	return claim, nil
+}
+
+// ReconcileBucketAccess reconciles the BucketAccess with the given namespaced name for unit tests.
+// BucketAccess should exist (if desired) in the bootstrapped dependencies's client.
+func ReconcileBucketAccess(
+	t *testing.T,
+	bootstrapped *cositest.Dependencies,
+	nsName types.NamespacedName,
+) (*cosiapi.BucketAccess, error) {
+	r := controller.BucketAccessReconciler{
+		Client: bootstrapped.Client,
+		Scheme: bootstrapped.Client.Scheme(),
+	}
+
+	_, err := r.Reconcile(bootstrapped.ContextWithLogger, ctrl.Request{NamespacedName: nsName})
+	if err != nil {
+		return nil, err
+	}
+
+	access := &cosiapi.BucketAccess{}
+	if err := bootstrapped.Client.Get(bootstrapped.ContextWithLogger, nsName, access); err != nil {
+		return nil, err
+	}
+	return access, nil
+}

--- a/internal/test/sidecar/test.go
+++ b/internal/test/sidecar/test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package sidecar contains utilities for unit testing that help approximate COSI Sidecar
+// behaviors.
+package sidecar
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2"
+	cositest "sigs.k8s.io/container-object-storage-interface/internal/test"
+	cosiproto "sigs.k8s.io/container-object-storage-interface/proto"
+	sidecar "sigs.k8s.io/container-object-storage-interface/sidecar/pkg/reconciler"
+)
+
+// ReconcileBucket reconciles the Bucket with the given namespaced name for unit tests.
+// Bucket should exist (if desired) in the bootstrapped dependencies's client.
+// It is suitable for unit testing behavior that relies on a Bucket to be reconciled as a
+// prerequisite. It is not suitable for unit testing Bucket reconciliation.
+func ReconcileBucket(
+	t *testing.T,
+	bootstrapped *cositest.Dependencies,
+	fakeServer *cositest.FakeProvisionerServer,
+	driverInfo sidecar.DriverInfo, // minus the RPC client
+	nsName types.NamespacedName,
+) (*cosiapi.Bucket, error) {
+	cleanup, serve, tmpSock, err := cositest.RpcServer(nil, fakeServer)
+	defer cleanup()
+	require.NoError(t, err)
+	go serve()
+
+	conn, err := cositest.RpcClientConn(tmpSock)
+	require.NoError(t, err)
+	rpcClient := cosiproto.NewProvisionerClient(conn)
+
+	r := sidecar.BucketReconciler{
+		Client:     bootstrapped.Client,
+		Scheme:     bootstrapped.Client.Scheme(),
+		DriverInfo: driverInfo,
+	}
+	r.DriverInfo.ProvisionerClient = rpcClient
+
+	_, err = r.Reconcile(bootstrapped.ContextWithLogger, ctrl.Request{NamespacedName: nsName})
+	if err != nil {
+		return nil, err
+	}
+
+	bucket := &cosiapi.Bucket{}
+	if err := bootstrapped.Client.Get(bootstrapped.ContextWithLogger, nsName, bucket); err != nil {
+		return nil, err
+	}
+	return bucket, nil
+}
+
+// ReconcileOpinionatedS3Bucket reconciles the Bucket with the given namespaced name for unit tests.
+// It uses a configurations that are compatible with the opinionated S3 driver and BucketClass.
+// It is suitable for unit testing behavior that relies on a Bucket to be reconciled as a
+// prerequisite. It is not suitable for unit testing Bucket reconciliation.
+func ReconcileOpinionatedS3Bucket(
+	t *testing.T,
+	bootstrapped *cositest.Dependencies,
+	nsName types.NamespacedName,
+) (*cosiapi.Bucket, error) {
+	fakeServer := cositest.FakeProvisionerServer{
+		// nolint:lll // long line is fine for test code
+		CreateBucketFunc: func(ctx context.Context, dcbr *cosiproto.DriverCreateBucketRequest) (*cosiproto.DriverCreateBucketResponse, error) {
+			ret := &cosiproto.DriverCreateBucketResponse{
+				BucketId: "cosi-" + dcbr.Name,
+				Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
+					S3: &cosiproto.S3BucketInfo{
+						Endpoint:        cositest.OpinionatedS3BucketClass().Spec.DriverName,
+						BucketId:        "cosi-" + dcbr.Name,
+						Region:          "us-east-1",
+						AddressingStyle: &cosiproto.S3AddressingStyle{Style: cosiproto.S3AddressingStyle_PATH},
+					},
+				},
+			}
+			return ret, nil
+		},
+	}
+
+	driverInfo := sidecar.DriverInfo{
+		Name: cositest.OpinionatedS3BucketClass().Spec.DriverName,
+		SupportedProtocols: []cosiproto.ObjectProtocol_Type{
+			cosiproto.ObjectProtocol_S3,
+		},
+	}
+
+	return ReconcileBucket(t, bootstrapped, &fakeServer, driverInfo, nsName)
+}
+
+// ReconcileOpinionatedGcsBucket reconciles the Bucket with the given namespaced name for unit tests.
+// It uses a configurations that are compatible with the opinionated GCS driver and BucketClass.
+// It is suitable for unit testing behavior that relies on a Bucket to be reconciled as a
+// prerequisite. It is not suitable for unit testing Bucket reconciliation.
+func ReconcileOpinionatedGcsBucket(
+	t *testing.T,
+	bootstrapped *cositest.Dependencies,
+	nsName types.NamespacedName,
+) (*cosiapi.Bucket, error) {
+	fakeServer := cositest.FakeProvisionerServer{
+		// nolint:lll // long line is fine for test code
+		CreateBucketFunc: func(ctx context.Context, dcbr *cosiproto.DriverCreateBucketRequest) (*cosiproto.DriverCreateBucketResponse, error) {
+			ret := &cosiproto.DriverCreateBucketResponse{
+				BucketId: "cosi-" + dcbr.Name,
+				Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
+					Gcs: &cosiproto.GcsBucketInfo{
+						ProjectId:  "cosi",
+						BucketName: "cosi-" + dcbr.Name,
+					},
+				},
+			}
+			return ret, nil
+		},
+	}
+
+	driverInfo := sidecar.DriverInfo{
+		Name: cositest.OpinionatedGcsBucketClass().Spec.DriverName,
+		SupportedProtocols: []cosiproto.ObjectProtocol_Type{
+			cosiproto.ObjectProtocol_GCS,
+		},
+	}
+
+	return ReconcileBucket(t, bootstrapped, &fakeServer, driverInfo, nsName)
+}
+
+// ReconcileOpinionatedAzureBucket reconciles the Bucket with the given namespaced name for unit tests.
+// It uses a configurations that are compatible with the opinionated Azure driver and BucketClass.
+// It is suitable for unit testing behavior that relies on a Bucket to be reconciled as a
+// prerequisite. It is not suitable for unit testing Bucket reconciliation.
+func ReconcileOpinionatedAzureBucket(
+	t *testing.T,
+	bootstrapped *cositest.Dependencies,
+	nsName types.NamespacedName,
+) (*cosiapi.Bucket, error) {
+	fakeServer := cositest.FakeProvisionerServer{
+		// nolint:lll // long line is fine for test code
+		CreateBucketFunc: func(ctx context.Context, dcbr *cosiproto.DriverCreateBucketRequest) (*cosiproto.DriverCreateBucketResponse, error) {
+			ret := &cosiproto.DriverCreateBucketResponse{
+				BucketId: "cosi-" + dcbr.Name,
+				Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
+					Azure: &cosiproto.AzureBucketInfo{
+						StorageAccount: "cosi",
+					},
+				},
+			}
+			return ret, nil
+		},
+	}
+
+	driverInfo := sidecar.DriverInfo{
+		Name: cositest.OpinionatedAzureBucketClass().Spec.DriverName,
+		SupportedProtocols: []cosiproto.ObjectProtocol_Type{
+			cosiproto.ObjectProtocol_AZURE,
+		},
+	}
+
+	return ReconcileBucket(t, bootstrapped, &fakeServer, driverInfo, nsName)
+}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/go-logr/logr/testr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -70,4 +72,109 @@ func MustBootstrap(t *testing.T, initialClientObjects ...client.Object) *Depende
 		Client:            client,
 		Logger:            logger,
 	}
+}
+
+// NsName returns the NamespacedName for the given object.
+func NsName(o client.Object) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: o.GetNamespace(),
+		Name:      o.GetName(),
+	}
+}
+
+// BucketNsName returns the NamespacedName for the Bucket bound to the given BucketClaim.
+func BucketNsName(claim *cosiapi.BucketClaim) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: "",
+		Name:      claim.Status.BoundBucketName,
+	}
+}
+
+// SecretNsName returns the NamespacedName for the Secret defined in the given BucketAccess
+// selected from the access's bucketClaims by index.
+func SecretNsName(access *cosiapi.BucketAccess, claimIndex int) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: access.Namespace,
+		Name:      access.Spec.BucketClaims[claimIndex].AccessSecretName,
+	}
+}
+
+// ObjectMetaWithUID returns ObjectMeta with the given namespace and name, and a deterministic UID
+// suitable for unit testing.
+func ObjectMetaWithUID(namespace, name string) ctrl.ObjectMeta {
+	return ctrl.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+		// not a real UID, but is deterministic and fine for unit testing
+		UID: types.UID(namespace + "-" + name),
+	}
+}
+
+// OpinionatedBucketClass returns a BucketClass with opinionated, working defaults for unit tests.
+// It is suitable for unit testing behavior that relies on a BucketClaim to be reconciled as a
+// prerequisite. It is not suitable for unit testing BucketClaim reconciliation.
+func OpinionatedBucketClass(identifier string) *cosiapi.BucketClass {
+	return &cosiapi.BucketClass{
+		ObjectMeta: ctrl.ObjectMeta{
+			Name: "opinionated-" + identifier,
+		},
+		Spec: cosiapi.BucketClassSpec{
+			DriverName:     identifier + ".cosi.test",
+			DeletionPolicy: cosiapi.BucketDeletionPolicyDelete,
+		},
+	}
+}
+
+// OpinionatedBucketClaim returns a BucketClaim with opinionated, working defaults for unit tests.
+// It is suitable for unit testing behavior that relies on a BucketClaim to be reconciled as a
+// prerequisite. It is not suitable for unit testing BucketClaim reconciliation.
+// nolint:lll // long line is fine for test code
+func OpinionatedBucketClaim(namespace, name, className string, protocols ...cosiapi.ObjectProtocol) *cosiapi.BucketClaim {
+	return &cosiapi.BucketClaim{
+		ObjectMeta: ObjectMetaWithUID(namespace, name),
+		Spec: cosiapi.BucketClaimSpec{
+			BucketClassName: className,
+			Protocols:       protocols,
+		},
+	}
+}
+
+// OpinionatedS3BucketClass returns a BucketClass configured for an opinionated S3 driver.
+// It is suitable for unit testing behavior that relies on a BucketClaim to be reconciled as a
+// prerequisite. It is not suitable for unit testing BucketClaim reconciliation.
+func OpinionatedS3BucketClass() *cosiapi.BucketClass {
+	return OpinionatedBucketClass("s3")
+}
+
+// OpinionatedS3BucketClaim returns an BucketClaim configured to use the opinionated S3 BucketClass.
+// It is suitable for unit testing behavior that relies on a BucketClaim to be reconciled as a
+// prerequisite. It is not suitable for unit testing BucketClaim reconciliation.
+func OpinionatedS3BucketClaim(namespace, name string) *cosiapi.BucketClaim {
+	return OpinionatedBucketClaim(namespace, name, OpinionatedS3BucketClass().Name, cosiapi.ObjectProtocolS3)
+}
+
+// OpinionatedGcsBucketClass returns a BucketClass configured for an opinionated GCS driver.
+// It is suitable for unit testing behavior that relies on a BucketClaim to be reconciled as a
+// prerequisite. It is not suitable for unit testing BucketClaim reconciliation.
+func OpinionatedGcsBucketClass() *cosiapi.BucketClass {
+	return OpinionatedBucketClass("gcs")
+}
+
+// OpinionatedGcsBucketClaim returns an BucketClaim configured to use the opinionated GCS BucketClass.
+// It is suitable for unit testing behavior that relies on a BucketClaim to be reconciled as a
+// prerequisite. It is not suitable for unit testing BucketClaim reconciliation.
+func OpinionatedGcsBucketClaim(namespace, name string) *cosiapi.BucketClaim {
+	return OpinionatedBucketClaim(namespace, name, OpinionatedGcsBucketClass().Name, cosiapi.ObjectProtocolGcs)
+}
+
+// OpinionatedAzureBucketClass returns a BucketClass configured for an opinionated Azure driver.
+func OpinionatedAzureBucketClass() *cosiapi.BucketClass {
+	return OpinionatedBucketClass("azure")
+}
+
+// OpinionatedAzureBucketClaim returns an BucketClaim configured to use the opinionated Azure BucketClass.
+// It is suitable for unit testing behavior that relies on a BucketClaim to be reconciled as a
+// prerequisite. It is not suitable for unit testing BucketClaim reconciliation.
+func OpinionatedAzureBucketClaim(namespace, name string) *cosiapi.BucketClaim {
+	return OpinionatedBucketClaim(namespace, name, OpinionatedAzureBucketClass().Name, cosiapi.ObjectProtocolAzure)
 }

--- a/vendor/sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
@@ -215,6 +215,16 @@ type AccessedBucket struct {
 	// +kubebuilder:validation:XValidation:message="name must be a valid resource name",rule="!format.dns1123Subdomain().validate(self).hasValue()"
 	BucketName string `json:"bucketName,omitempty"`
 
+	// bucketID is the unique identifier for the backend bucket known to the driver for which
+	// this access should have permissions.
+	// Must be at most 2048 characters and consist only of alphanumeric characters ([a-z0-9A-Z]),
+	// dashes (-), dots (.), underscores (_), and forward slash (/).
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=2048
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9/._-]+$`
+	BucketID string `json:"bucketID,omitempty"`
+
 	// bucketClaimName must match a BucketClaimAccess's BucketClaimName from the spec.
 	// Must be a valid Kubernetes resource name: at most 253 characters, consisting only of
 	// lower-case alphanumeric characters, hyphens, and periods, starting and ending with an


### PR DESCRIPTION
When BucketAccess status.accessedBuckets tracks Buckets by name instead of ID, BucketAccess deletion can be rendered impossible if a Bucket resource gets lost or is force-deleted by an admin.

Modify accessedBuckets to track Buckets by ID instead.

This requires updating BucketAccess initialization in the COSI Controller as well as BucketAccess provisioning in the Sidecar.

Additionally, because the Controller needs to get info from reconciled
Buckets, unit testing is no longer so simple to scaffold. Begin using
the BucketClaim reconciler to provision Buckets, Bucket reconciler to
make them ready, and BucketClaim reconciler to finalize BucketClaim
readiness.

Because the BucketAccess is also similarly affected, begin using the
Controller's BucketAccess initialization to get the BucketAccess itself
into the right state including Bucket information before Sidecar unit
tests.

Tests represent the largest part of the rework needed.

Resolves #228 