### PR TITLE
add linter to ensure end of file newlines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ export
 all: prebuild build ## Build all container images, plus their prerequisites (faster with 'make -j')
 
 .PHONY: lint
-lint: golangci-lint kubeapi-lint spell-lint dockerfiles-lint ## Run all linters (suggest `make -k`)
+lint: golangci-lint kubeapi-lint spell-lint eof-newline-lint dockerfiles-lint ## Run all linters (suggest `make -k`)
 golangci-lint: golangci-lint
 	$(GOLANGCI_LINT) run $(GOLANGCI_LINT_RUN_OPTS) --config $(CURDIR)/.golangci.yaml
 kubeapi-lint: kube-api-linter
@@ -65,6 +65,8 @@ spell-lint:
 	git ls-files | grep -v -e CHANGELOG -e go.mod -e go.sum -e vendor | xargs $(SPELL_LINT) -i "Creater,creater,ect" -error -o stderr
 dockerfiles-lint:
 	hack/tools/lint-dockerfiles.sh $(HADOLINT_VERSION)
+eof-newline-lint:
+	hack/lint-eof-newline.sh
 
 .PHONY: lint-fix
 lint-fix: golangci-lint-fix ## Run all linters and perform fixes where possible (suggest `make -k`)

--- a/hack/lint-eof-newline.sh
+++ b/hack/lint-eof-newline.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+# set -o xtrace
+
+function file_ends_with_newline() {
+    [[ $(tail -c1 "$1" | wc -l) -gt 0 ]]
+}
+
+any_failure=false
+
+for file in $(git ls-files -- . ':(exclude)vendor/*' ) ; do
+  if ! file_ends_with_newline "$file" ; then
+    echo "FAIL: $file -- no newline at end of file"
+    any_failure=true
+  fi
+done
+
+if $any_failure ; then
+  exit 1
+fi


### PR DESCRIPTION
Many code editors are configured to ensure a newline exists at the end of all files. Some editors ensure the opposite. This results in unnecessary changes in PRs on occasion. To ensure this doesn't occur, add a bash script to lint files to ensure a newline exists. This is the safest preference because it is a POSIX standard.