### PR TITLE
fix(release-0.2): retry on Bucket update conflict during BucketAccess reconcile

### DIFF
--- a/sidecar/pkg/bucketaccess/bucketaccess_controller.go
+++ b/sidecar/pkg/bucketaccess/bucketaccess_controller.go
@@ -31,6 +31,7 @@ import (
 	kube "k8s.io/client-go/kubernetes"
 	kubecorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	cosiapi "sigs.k8s.io/container-object-storage-interface/client/apis"
 	"sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/consts"
@@ -273,11 +274,22 @@ func (bal *BucketAccessListener) Add(ctx context.Context, inputBucketAccess *v1a
 		}
 	}
 
-	if controllerutil.AddFinalizer(bucket, consts.BABucketFinalizer) {
-		_, err = bal.buckets().Update(ctx, bucket, metav1.UpdateOptions{})
-		if err != nil {
-			return bal.recordError(inputBucketAccess, v1.EventTypeWarning, v1alpha1.FailedGrantAccess, err)
+	// Re-fetch and update inside RetryOnConflict to handle the case where the Bucket
+	// reconciler in the same controller process mutates the Bucket between our Get
+	// and Update, which surfaces as "the object has been modified" on the parent
+	// Bucket and emits FailedGrantAccess on the BucketAccess.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, getErr := bal.buckets().Get(ctx, bucketClaim.Status.BucketName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
 		}
+		if !controllerutil.AddFinalizer(latest, consts.BABucketFinalizer) {
+			return nil
+		}
+		_, updateErr := bal.buckets().Update(ctx, latest, metav1.UpdateOptions{})
+		return updateErr
+	}); err != nil {
+		return bal.recordError(inputBucketAccess, v1.EventTypeWarning, v1alpha1.FailedGrantAccess, err)
 	}
 
 	if controllerutil.AddFinalizer(bucketAccess, consts.BAFinalizer) {


### PR DESCRIPTION
## What this PR does

Carries the same `RetryOnConflict` pattern adopted in #197 (BucketClaim controller) into the BucketAccess sidecar reconciler, where the same race exists on the parent Bucket finalizer-add path.

In `sidecar/pkg/bucketaccess/bucketaccess_controller.go`, the `Add` path does:

```go
bucket, _ := buckets().Get(...)
// ...
if controllerutil.AddFinalizer(bucket, BABucketFinalizer) {
    buckets().Update(ctx, bucket, ...)   // <-- 409 here
}
```

Between `Get` and `Update`, the Bucket reconciler running in the same controller process can mutate the object and bump `resourceVersion`, producing:

```
Operation cannot be fulfilled on buckets.objectstorage.k8s.io "bucket-...":
the object has been modified; please apply your changes to the latest
version and try again
```

surfaced to users as a `FailedGrantAccess` event on the BucketAccess.

This PR wraps the Bucket finalizer add in `retry.RetryOnConflict(retry.DefaultRetry, ...)` and re-`Get`s the Bucket inside the closure so each retry mutates the freshest version. Same pattern as #197.

## Why release-0.2 only

The same code path does not exist on `main` — the v1alpha2 BucketAccess sidecar (`sidecar/pkg/reconciler/bucketaccess.go`) only reads Buckets and only mutates the `BucketAccess` itself, so the cross-object Bucket finalizer race is gone architecturally.

## Related

- #173 — Bug class: "object has been modified" during reconcile
- #197 — Same fix, BucketClaim controller (merged into release-0.2)
- #166 — Open ask to track these conflicts in CI

### Release note

~~~release-note
[sidecar] Retry on Bucket update conflict during BucketAccess reconcile to eliminate spurious FailedGrantAccess events caused by the in-process race between the Bucket and BucketAccess reconcilers.
~~~

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./sidecar/pkg/bucketaccess/...` passes
- [x] Manual verification: the `FailedGrantAccess: ... object has been modified` event reproducible against v0.2.2 stops firing once the patch is applied.