### PR TITLE
build: update gcb-docker-gcloud to v20260205-38cfa9523f (digest-pinned)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,7 +15,7 @@ substitutions:
   _PLATFORMS: linux/amd64,linux/arm64 # add more platforms here if desired
 steps:
   - id: do-multi-arch-build-all-images
-    name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
+    name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2 # v20260205-38cfa9523f
     args:
       - hack/cloudbuild.sh
     env:


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:
The gcb-docker-gcloud:v20250513-9264efb079 image tag used in cloudbuild.yaml has been garbage collected from the staging registry, causing cloud build jobs to fail with manifest unknown errors. Updates to digest-pinned v20260205-38cfa9523f.

Which issue(s) this PR fixes:
Fixes kubernetes/kubernetes#138936

Special notes for your reviewer:
Digest: sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2
Tag: v20260205-38cfa9523f

Does this PR introduce a user-facing change?:


NONE