### PR TITLE
Add regression test for delayed static BucketClaim binding

### DIFF
--- a/controller/pkg/reconciler/reconciler_test/bucketclaim_test.go
+++ b/controller/pkg/reconciler/reconciler_test/bucketclaim_test.go
@@ -615,6 +615,48 @@ func TestBucketClaimReconcile(t *testing.T) {
 			})
 		})
 
+		t.Run("bucket created after initial reconcile", func(t *testing.T) {
+			bootstrapped := cositest.MustBootstrap(t,
+				baseStaticClaim.DeepCopy(),
+				// no bucket
+			)
+			r := claimReconcilerForClient(bootstrapped.Client)
+			ctx := bootstrapped.ContextWithLogger
+
+			res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseStaticClaim)})
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
+			assert.ErrorContains(t, err, "waiting for statically-provisioned Bucket")
+			assert.Empty(t, res)
+
+			require.NoError(t, bootstrapped.Client.Create(ctx, baseStaticBucket.DeepCopy()))
+
+			bucket, err := sidecartest.ReconcileOpinionatedS3Bucket(
+				t,
+				bootstrapped,
+				cositest.NsName(&baseStaticBucket),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, bucket.Status.ReadyToUse)
+			require.True(t, *bucket.Status.ReadyToUse)
+
+			res, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseStaticClaim)})
+			assert.NoError(t, err)
+			assert.Empty(t, res)
+
+			claim, dynamicBucket, staticBucket := getAllClaimResources(bootstrapped)
+
+			require.NotNil(t, claim)
+			assert.Contains(t, claim.GetFinalizers(), cosiapi.ProtectionFinalizer)
+			assert.Equal(t, "static-bucket", claim.Status.BoundBucketName)
+			assert.Equal(t, bucket.Status.ReadyToUse, claim.Status.ReadyToUse)
+			assert.Equal(t, bucket.Status.Protocols, claim.Status.Protocols)
+			assert.Nil(t, claim.Status.Error)
+
+			assert.Nil(t, dynamicBucket)
+			assert.Equal(t, bucket.Status, staticBucket.Status)
+		})
+
 		t.Run("bucket bucketClaimRef mismatch", func(t *testing.T) {
 			type bucketClaimRefMismatchTest struct {
 				testName      string


### PR DESCRIPTION
Refs #285

This adds regression coverage for a static `BucketClaim` whose referenced `Bucket` is created after the claim initially reconciles. The test verifies that after the Bucket is later reconciled and marked ready, the next BucketClaim reconcile binds `status.boundBucketName`, copies Bucket readiness/protocol status, clears the prior waiting error, and does not create a dynamic Bucket.

Current `main` already appears to handle this flow correctly; this test documents that behavior and should help prevent regressions around the delayed static-provisioning sequence reported in the issue.

Tests:
- `go test ./controller/pkg/reconciler/...`
- `go test ./...`