### PR TITLE
BucketClaim deletion: ensure BucketAccesses blocks deletion (controller)

### DIFF
--- a/controller/pkg/reconciler/bucketclaim.go
+++ b/controller/pkg/reconciler/bucketclaim.go
@@ -114,8 +114,9 @@ func (r *BucketClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				cosipredicate.AnyDelete(),
 				cosipredicate.AnyGeneric(),
 				// opt in to desired Update events
-				cosipredicate.GenerationChangedInUpdateOnly(),      // reconcile spec changes
-				cosipredicate.ProtectionFinalizerRemoved(r.Scheme), // re-add protection finalizer if removed
+				cosipredicate.GenerationChangedInUpdateOnly(),              // reconcile spec changes
+				cosipredicate.ProtectionFinalizerRemoved(r.Scheme),         // re-add protection finalizer if removed
+				cosipredicate.BucketAccessRefChangedInUpdateOnly(r.Scheme), // resume blocked deletion
 			),
 		).
 		Named("bucketclaim"). // TODO: .Owns(&cosiapi.Bucket{}, builder.WithPredicates(...))
@@ -245,6 +246,25 @@ func (r *BucketClaimReconciler) reconcileDelete(
 	bucketName string,
 	isStaticProvisioning bool,
 ) error {
+	// If BucketAccess reference annotation exists on the BucketClaim, exit without retry
+	if hasBucketAccessReferencesAnnotation(claim) {
+		logger.Info("waiting for BucketAccess cleanup before deleting BucketClaim")
+		return nil
+	}
+
+	// Re-check for any race protection.
+	// If BucketAccesses object referencing the BucketClaim still exist, block deletion.
+	referencingAccessNames, err := listReferencingBucketAccessNames(ctx, r.Client, claim)
+	if err != nil {
+		logger.Error(err, "failed to verify BucketAccess references before BucketClaim deletion")
+		return err
+	}
+	if len(referencingAccessNames) > 0 {
+		logger.Info("waiting for BucketAccess cleanup before deleting BucketClaim",
+			"referencingBucketAccesses", referencingAccessNames)
+		return nil
+	}
+
 	claim.Status.ReadyToUse = ptr.To(false)
 	claim.Status.Error = nil // previous error is no longer relevant
 	if err := r.Status().Update(ctx, claim); err != nil {
@@ -323,6 +343,36 @@ func (r *BucketClaimReconciler) reconcileDelete(
 		logger.Error(nil, "unknown Bucket deletion policy", "deletionPolicy", bucket.Spec.DeletionPolicy)
 		return cosierr.NonRetryableError(fmt.Errorf("unknown Bucket deletion policy %q", bucket.Spec.DeletionPolicy))
 	}
+}
+
+func hasBucketAccessReferencesAnnotation(claim *cosiapi.BucketClaim) bool {
+	if claim.Annotations == nil {
+		return false
+	}
+	_, ok := claim.Annotations[cosiapi.HasBucketAccessReferencesAnnotation]
+	return ok
+}
+
+func listReferencingBucketAccessNames(
+	ctx context.Context,
+	cl client.Client,
+	claim *cosiapi.BucketClaim,
+) ([]string, error) {
+	accessList := cosiapi.BucketAccessList{}
+	if err := cl.List(ctx, &accessList, &client.ListOptions{Namespace: claim.Namespace}); err != nil {
+		return nil, fmt.Errorf("failed to list BucketAccesses in claim namespace: %w", err)
+	}
+
+	references := []string{}
+	for _, access := range accessList.Items {
+		for _, ref := range access.Spec.BucketClaims {
+			if ref.BucketClaimName == claim.Name {
+				references = append(references, access.Name)
+				break
+			}
+		}
+	}
+	return references, nil
 }
 
 func (r *BucketClaimReconciler) removeClaimFinalizer(

--- a/controller/pkg/reconciler/reconciler_test/bucketclaim_test.go
+++ b/controller/pkg/reconciler/reconciler_test/bucketclaim_test.go
@@ -355,6 +355,83 @@ func deletionTestSuiteWithoutBucket(t *testing.T,
 	bootstrapped.AssertResourceDoesNotExist(t, cositest.BucketNsName(initClaim), &cosiapi.Bucket{})
 }
 
+func deletionBlockedByBucketAccessReferenceSuite(t *testing.T, deps *cositest.Dependencies) {
+	t.Run("annotation present, blocks deletion", func(t *testing.T) {
+		bootstrapped := deps.MustCopy()
+		ctx := bootstrapped.ContextWithLogger
+		r := claimReconcilerForClient(bootstrapped.Client)
+
+		initClaim, initBucket := getClaimAndBucket(bootstrapped)
+		require.NotNil(t, initClaim)
+		require.NotNil(t, initBucket)
+
+		if initClaim.Annotations == nil {
+			initClaim.Annotations = map[string]string{}
+		}
+		initClaim.Annotations[cosiapi.HasBucketAccessReferencesAnnotation] = ""
+		require.NoError(t, r.Update(ctx, initClaim))
+		require.NoError(t, r.Delete(ctx, initClaim))
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseDynamicClaim)})
+		assert.NoError(t, err)
+		assert.Empty(t, res)
+
+		claim, bucket := getClaimAndBucket(bootstrapped)
+		require.NotNil(t, claim)
+		require.NotNil(t, bucket)
+		assert.Contains(t, claim.GetFinalizers(), cosiapi.ProtectionFinalizer)
+		assert.Contains(t, claim.GetAnnotations(), cosiapi.HasBucketAccessReferencesAnnotation)
+		assert.Zero(t, bucket.GetDeletionTimestamp())
+		assert.NotContains(t, bucket.GetAnnotations(), cosiapi.BucketClaimBeingDeletedAnnotation)
+	})
+
+	t.Run("race protection re-check, blocks when annotation missing", func(t *testing.T) {
+		bootstrapped := deps.MustCopy()
+		ctx := bootstrapped.ContextWithLogger
+		r := claimReconcilerForClient(bootstrapped.Client)
+
+		initClaim, initBucket := getClaimAndBucket(bootstrapped)
+		require.NotNil(t, initClaim)
+		require.NotNil(t, initBucket)
+
+		access := &cosiapi.BucketAccess{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-access",
+				Namespace: initClaim.Namespace,
+			},
+			Spec: cosiapi.BucketAccessSpec{
+				BucketAccessClassName: "ignored",
+				Protocol:              cosiapi.ObjectProtocolS3,
+				BucketClaims: []cosiapi.BucketClaimAccess{
+					{
+						BucketClaimName: initClaim.Name,
+						AccessMode:      cosiapi.BucketAccessModeReadWrite,
+					},
+				},
+			},
+		}
+		require.NoError(t, r.Create(ctx, access))
+
+		if initClaim.Annotations != nil {
+			delete(initClaim.Annotations, cosiapi.HasBucketAccessReferencesAnnotation)
+		}
+		require.NoError(t, r.Update(ctx, initClaim))
+		require.NoError(t, r.Delete(ctx, initClaim))
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseDynamicClaim)})
+		assert.NoError(t, err)
+		assert.Empty(t, res)
+
+		claim, bucket := getClaimAndBucket(bootstrapped)
+		require.NotNil(t, claim)
+		require.NotNil(t, bucket)
+		assert.Contains(t, claim.GetFinalizers(), cosiapi.ProtectionFinalizer)
+		assert.NotContains(t, claim.GetAnnotations(), cosiapi.HasBucketAccessReferencesAnnotation)
+		assert.Zero(t, bucket.GetDeletionTimestamp())
+		assert.NotContains(t, bucket.GetAnnotations(), cosiapi.BucketClaimBeingDeletedAnnotation)
+	})
+}
+
 func TestBucketClaimReconcile(t *testing.T) {
 	// A lot of things can happen after successful initialization. Test all of them, building off of
 	// successful initialization with subsequent tests.
@@ -756,5 +833,10 @@ func TestBucketClaimReconcile(t *testing.T) {
 				})
 			}
 		})
+	})
+
+	t.Run("deletion blocked by BucketAccess references", func(t *testing.T) {
+		bootstrapped := dynamicInitializationTest(t)
+		deletionBlockedByBucketAccessReferenceSuite(t, bootstrapped)
 	})
 }

--- a/internal/predicate/predicate.go
+++ b/internal/predicate/predicate.go
@@ -187,6 +187,52 @@ func BucketAccessManagedByController(s *runtime.Scheme) predicate.Funcs {
 	})
 }
 
+// BucketAccessRefChangedInUpdateOnly implements a predicate that enqueues a BucketClaim reconcile for
+// Update events where BucketAccess reference annotation presence changes while the claim is
+// deleting. This helps unblock deletions that intentionally return without retry when annotation
+// still exist.
+//
+// The predicate does not enqueue requests for any Create/Delete/Generic events.
+func BucketAccessRefChangedInUpdateOnly(s *runtime.Scheme) predicate.Funcs {
+	funcs := allFalseFuncs()
+	funcs.UpdateFunc = func(e event.UpdateEvent) bool {
+		logger := ctrl.Log.WithName("predicate")
+
+		oldClaim, ok := toTypedOrLogError[*cosiapi.BucketClaim](logger.WithValues("oldOrNew", "old"), s, e.ObjectOld)
+		if !ok {
+			return false
+		}
+		newClaim, ok := toTypedOrLogError[*cosiapi.BucketClaim](logger.WithValues("oldOrNew", "new"), s, e.ObjectNew)
+		if !ok {
+			return false
+		}
+
+		// Reconcile is only required for claims currently undergoing deletion.
+		if newClaim.GetDeletionTimestamp().IsZero() {
+			return false
+		}
+
+		oldHasMark := false
+		if oldClaim.Annotations != nil {
+			_, oldHasMark = oldClaim.Annotations[cosiapi.HasBucketAccessReferencesAnnotation]
+		}
+		newHasMark := false
+		if newClaim.Annotations != nil {
+			_, newHasMark = newClaim.Annotations[cosiapi.HasBucketAccessReferencesAnnotation]
+		}
+
+		if oldHasMark != newHasMark {
+			logger.Info("BucketClaim access reference mark changed during deletion",
+				"namespace", newClaim.GetNamespace(), "name", newClaim.GetName(),
+				"oldHasMark", oldHasMark, "newHasMark", newHasMark)
+			return true
+		}
+
+		return false
+	}
+	return funcs
+}
+
 // Converts a client object to a typed object. Logs an error if conversion fails.
 func toTypedOrLogError[T client.Object](logger logr.Logger, s *runtime.Scheme, object client.Object) (T, bool) {
 	typed, ok := object.(T)

--- a/internal/predicate/predicate_test.go
+++ b/internal/predicate/predicate_test.go
@@ -25,6 +25,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -92,4 +93,61 @@ func Test_handoffOccurred(t *testing.T) {
 		assert.True(t, handoffOccurred(logger, old, new))
 	})
 
+}
+
+func TestBucketAccessRefChangedInUpdateOnly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, cosiapi.AddToScheme(scheme))
+	p := BucketAccessRefChangedInUpdateOnly(scheme)
+
+	t.Run("deleting claim mark removed", func(t *testing.T) {
+		oldClaim := &cosiapi.BucketClaim{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "ns",
+				Name:      "claim",
+				Annotations: map[string]string{
+					cosiapi.HasBucketAccessReferencesAnnotation: "",
+				},
+			},
+		}
+		now := meta.Now()
+		newClaim := oldClaim.DeepCopy()
+		newClaim.DeletionTimestamp = &now
+		delete(newClaim.Annotations, cosiapi.HasBucketAccessReferencesAnnotation)
+
+		assert.True(t, p.Update(event.UpdateEvent{ObjectOld: oldClaim, ObjectNew: newClaim}))
+	})
+
+	t.Run("deleting claim mark unchanged", func(t *testing.T) {
+		now := meta.Now()
+		oldClaim := &cosiapi.BucketClaim{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace:         "ns",
+				Name:              "claim",
+				DeletionTimestamp: &now,
+				Annotations: map[string]string{
+					cosiapi.HasBucketAccessReferencesAnnotation: "",
+				},
+			},
+		}
+		newClaim := oldClaim.DeepCopy()
+
+		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: oldClaim, ObjectNew: newClaim}))
+	})
+
+	t.Run("non-deleting claim mark changed", func(t *testing.T) {
+		oldClaim := &cosiapi.BucketClaim{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "ns",
+				Name:      "claim",
+				Annotations: map[string]string{
+					cosiapi.HasBucketAccessReferencesAnnotation: "",
+				},
+			},
+		}
+		newClaim := oldClaim.DeepCopy()
+		delete(newClaim.Annotations, cosiapi.HasBucketAccessReferencesAnnotation)
+
+		assert.False(t, p.Update(event.UpdateEvent{ObjectOld: oldClaim, ObjectNew: newClaim}))
+	})
 }


### PR DESCRIPTION
https://github.com/kubernetes-sigs/container-object-storage-interface/issues/165

Block BucketClaim deletion while any BucketAccess still references it.