### PR TITLE
Rename protocol output secret/envvar names

### DIFF
--- a/client/apis/objectstorage/v1alpha2/bucket_types.go
+++ b/client/apis/objectstorage/v1alpha2/bucket_types.go
@@ -165,9 +165,9 @@ type BucketStatus struct {
 	// +kubebuilder:validation:MaxItems=3
 	Protocols []ObjectProtocol `json:"protocols,omitempty"`
 
-	// bucketInfo contains info about the bucket reported by the driver, rendered in the same
-	// COSI_<PROTOCOL>_<KEY> format used for the BucketAccess Secret.
-	// e.g., COSI_S3_ENDPOINT, COSI_AZURE_STORAGE_ACCOUNT.
+	// bucketInfo contains info about the bucket reported by the driver, rendered in the
+	// well-known env var key format used for the BucketAccess Secret.
+	// e.g., AWS_ENDPOINT_URL, AZURE_STORAGE_ACCOUNT.
 	// This should not contain any sensitive information.
 	// +optional
 	// +kubebuilder:validation:MinProperties=1

--- a/client/apis/objectstorage/v1alpha2/protocols.go
+++ b/client/apis/objectstorage/v1alpha2/protocols.go
@@ -37,24 +37,24 @@ const (
 	ObjectProtocolGcs ObjectProtocol = "GCS"
 )
 
-// A CosiEnvVar defines a COSI environment variable that contains backend bucket or access info.
+// A CosiEnvVar defines an environment variable that contains backend bucket or access info.
 // Vars marked "Required" will be present with non-empty values in BucketAccess Secrets.
 // Some required vars may only be required in certain contexts, like when a specific
 // AuthenticationType is used.
 // Some vars are only relevant for specific protocols.
 // Non-relevant vars will not be present, even when marked "Required".
 // Vars are used as data keys in BucketAccess Secrets.
-// Vars must be all-caps and must begin with `COSI_`.
+// Vars must be all-caps.
 type CosiEnvVar string
 
 // A BucketInfoVar defines a protocol-specific COSI environment variable that contains backend
 // bucket info.
-// All protocol-specific vars include the all-caps protocol name after `COSI_`. E.g., `COSI_AZURE_`.
+// Protocol-specific vars use well-known ecosystem names when available.
 type BucketInfoVar CosiEnvVar
 
 // A CredentialVar defines a protocol-specific COSI environment variable that contains backend
 // bucket access credential info.
-// All protocol-specific vars include the all-caps protocol name after `COSI_`. E.g., `COSI_AZURE_`.
+// Protocol-specific vars use well-known ecosystem names when available.
 type CredentialVar CosiEnvVar
 
 const (
@@ -73,26 +73,26 @@ const (
 // bucket info vars
 const (
 	// Required. The S3 bucket ID as used by clients.
-	BucketInfoVar_S3_BucketId BucketInfoVar = "COSI_S3_BUCKET_ID"
+	BucketInfoVar_S3_BucketId BucketInfoVar = "BUCKET_NAME"
 
 	// Required. The S3 endpoint for the bucket.
-	BucketInfoVar_S3_Endpoint BucketInfoVar = "COSI_S3_ENDPOINT"
+	BucketInfoVar_S3_Endpoint BucketInfoVar = "AWS_ENDPOINT_URL"
 
 	// Required. The S3 region for the bucket.
-	BucketInfoVar_S3_Region BucketInfoVar = "COSI_S3_REGION"
+	BucketInfoVar_S3_Region BucketInfoVar = "AWS_DEFAULT_REGION"
 
 	// Required. The S3 addressing style. One of `path` or `virtual`.
 	// See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html.
-	BucketInfoVar_S3_AddressingStyle BucketInfoVar = "COSI_S3_ADDRESSING_STYLE"
+	BucketInfoVar_S3_AddressingStyle BucketInfoVar = "AWS_S3_ADDRESSING_STYLE"
 )
 
 // nolint:gosec // credential vars, not hardcoded credentials
 const (
 	// Required for `AuthenticationType=Key`. The S3 access key ID.
-	CredentialVar_S3_AccessKeyId CredentialVar = "COSI_S3_ACCESS_KEY_ID" // nolint:gosec // no a cred
+	CredentialVar_S3_AccessKeyId CredentialVar = "AWS_ACCESS_KEY_ID" // nolint:gosec // no a cred
 
 	// Required for `AuthenticationType=Key`. The S3 access secret key.
-	CredentialVar_S3_AccessSecretKey CredentialVar = "COSI_S3_ACCESS_SECRET_KEY" // nolint:gosec // no a cred
+	CredentialVar_S3_AccessSecretKey CredentialVar = "AWS_SECRET_ACCESS_KEY" // nolint:gosec // no a cred
 )
 
 /*
@@ -102,7 +102,7 @@ const (
 // bucket info vars
 const (
 	// Required. The ID of the Azure storage account.
-	BucketInfoVar_Azure_StorageAccount BucketInfoVar = "COSI_AZURE_STORAGE_ACCOUNT"
+	BucketInfoVar_Azure_StorageAccount BucketInfoVar = "AZURE_STORAGE_ACCOUNT"
 )
 
 // nolint:gosec // credential vars, not hardcoded credentials
@@ -110,11 +110,11 @@ const (
 	// Required for `AuthenticationType=Key`. Azure SAS access token.
 	// Note that this includes the resource URI as well as token in its definition.
 	// See: https://learn.microsoft.com/en-us/azure/storage/common/media/storage-sas-overview/sas-storage-uri.svg
-	CredentialVar_Azure_AccessToken CredentialVar = "COSI_AZURE_ACCESS_TOKEN"
+	CredentialVar_Azure_AccessToken CredentialVar = "AZURE_STORAGE_SAS_TOKEN"
 
 	// Optional. The timestamp when access will expire.
 	// Empty if unset. Otherwise, date+time in ISO 8601 format.
-	CredentialVar_Azure_ExpiryTimestamp CredentialVar = "COSI_AZURE_EXPIRY_TIMESTAMP"
+	CredentialVar_Azure_ExpiryTimestamp CredentialVar = "AZURE_STORAGE_SAS_TOKEN_EXPIRY_TIMESTAMP"
 )
 
 /*
@@ -124,23 +124,23 @@ const (
 // bucket info vars
 const (
 	// Required. The GCS project ID.
-	BucketInfoVar_GCS_ProjectId BucketInfoVar = "COSI_GCS_PROJECT_ID"
+	BucketInfoVar_GCS_ProjectId BucketInfoVar = "PROJECT_ID"
 
 	// Required. GCS bucket name as used by clients.
-	BucketInfoVar_GCS_BucketName BucketInfoVar = "COSI_GCS_BUCKET_NAME"
+	BucketInfoVar_GCS_BucketName BucketInfoVar = "BUCKET_NAME"
 )
 
 // nolint:gosec // credential vars, not hardcoded credentials
 const (
 	// Required for `AuthenticationType=Key`. HMAC access ID.
-	CredentialVar_GCS_AccessId CredentialVar = "COSI_GCS_ACCESS_ID"
+	CredentialVar_GCS_AccessId CredentialVar = "HMAC_ACCESS_ID"
 
 	// Required for `AuthenticationType=Key`. HMAC secret.
-	CredentialVar_GCS_AccessSecret CredentialVar = "COSI_GCS_ACCESS_SECRET"
+	CredentialVar_GCS_AccessSecret CredentialVar = "HMAC_SECRET"
 
 	// GCS private key name.
-	CredentialVar_GCS_PrivateKeyName CredentialVar = "COSI_GCS_PRIVATE_KEY_NAME"
+	CredentialVar_GCS_PrivateKeyName CredentialVar = "PRIVATE_KEY_ID"
 
 	// GCS service account name.
-	CredentialVar_GCS_ServiceAccount CredentialVar = "COSI_GCS_SERVICE_ACCOUNT"
+	CredentialVar_GCS_ServiceAccount CredentialVar = "SERVICE_ACCOUNT_NAME"
 )

--- a/client/config/crd/objectstorage.k8s.io_buckets.yaml
+++ b/client/config/crd/objectstorage.k8s.io_buckets.yaml
@@ -198,9 +198,9 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  bucketInfo contains info about the bucket reported by the driver, rendered in the same
-                  COSI_<PROTOCOL>_<KEY> format used for the BucketAccess Secret.
-                  e.g., COSI_S3_ENDPOINT, COSI_AZURE_STORAGE_ACCOUNT.
+                  bucketInfo contains info about the bucket reported by the driver, rendered in the
+                  well-known env var key format used for the BucketAccess Secret.
+                  e.g., AWS_ENDPOINT_URL, AZURE_STORAGE_ACCOUNT.
                   This should not contain any sensitive information.
                 maxProperties: 128
                 minProperties: 1

--- a/docs/src/api/out.md
+++ b/docs/src/api/out.md
@@ -500,7 +500,7 @@ _Appears in:_
 | `readyToUse` _boolean_ | readyToUse indicates that the bucket is ready for consumption by workloads. |  |  |
 | `bucketID` _string_ | bucketID is the unique identifier for the backend bucket known to the driver.<br />Must be at most 2048 characters and consist only of alphanumeric characters ([a-z0-9A-Z]),<br />dashes (-), dots (.), underscores (_), and forward slash (/). |  | MaxLength: 2048 <br />MinLength: 1 <br />Pattern: `^[a-zA-Z0-9/._-]+$` <br /> |
 | `protocols` _[ObjectProtocol](#objectprotocol) array_ | protocols is the set of protocols the Bucket reports to support. BucketAccesses can request<br />access to this Bucket using any of the protocols reported here.<br />Possible values: 'S3', 'Azure', 'GCS'. |  | Enum: [S3 Azure GCS] <br />MaxItems: 3 <br />MinItems: 1 <br /> |
-| `bucketInfo` _object (keys:string, values:string)_ | bucketInfo contains info about the bucket reported by the driver, rendered in the same<br />COSI_<PROTOCOL>_<KEY> format used for the BucketAccess Secret.<br />e.g., COSI_S3_ENDPOINT, COSI_AZURE_STORAGE_ACCOUNT.<br />This should not contain any sensitive information. |  | MaxProperties: 128 <br />MinProperties: 1 <br /> |
+| `bucketInfo` _object (keys:string, values:string)_ | bucketInfo contains info about the bucket reported by the driver, rendered in the<br />well-known env var key format used for the BucketAccess Secret.<br />e.g., AWS_ENDPOINT_URL, AZURE_STORAGE_ACCOUNT.<br />This should not contain any sensitive information. |  | MaxProperties: 128 <br />MinProperties: 1 <br /> |
 | `error` _[TimestampedError](#timestampederror)_ | error holds the most recent error message, with a timestamp.<br />This is cleared when provisioning is successful. |  | MinProperties: 0 <br /> |
 
 
@@ -508,14 +508,14 @@ _Appears in:_
 
 _Underlying type:_ _string_
 
-A CosiEnvVar defines a COSI environment variable that contains backend bucket or access info.
+A CosiEnvVar defines an environment variable that contains backend bucket or access info.
 Vars marked "Required" will be present with non-empty values in BucketAccess Secrets.
 Some required vars may only be required in certain contexts, like when a specific
 AuthenticationType is used.
 Some vars are only relevant for specific protocols.
 Non-relevant vars will not be present, even when marked "Required".
 Vars are used as data keys in BucketAccess Secrets.
-Vars must be all-caps and must begin with `COSI_`.
+Vars must be all-caps.
 
 
 

--- a/internal/protocol/azure_test.go
+++ b/internal/protocol/azure_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package protocol
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,10 +92,6 @@ func TestAzureBucketInfoTranslator_RpcToApi(t *testing.T) {
 			s := AzureBucketInfoTranslator{}
 			api := s.RpcToApi(tt.rpc)
 			assert.Equal(t, tt.wantApi, api)
-
-			for k := range api {
-				assert.True(t, strings.HasPrefix(string(k), "COSI_AZURE_"))
-			}
 		})
 	}
 }
@@ -184,10 +179,6 @@ func TestAzureCredentialTranslator_RpcToApi(t *testing.T) {
 			s := AzureCredentialTranslator{}
 			api := s.RpcToApi(tt.rpc)
 			assert.Equal(t, tt.wantApi, api)
-
-			for k := range api {
-				assert.True(t, strings.HasPrefix(string(k), "COSI_AZURE_"))
-			}
 		})
 	}
 }

--- a/internal/protocol/gcs_test.go
+++ b/internal/protocol/gcs_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package protocol
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,10 +99,6 @@ func TestGcsBucketInfoTranslator_RpcToApi(t *testing.T) {
 			s := GcsBucketInfoTranslator{}
 			api := s.RpcToApi(tt.rpc)
 			assert.Equal(t, tt.wantApi, api)
-
-			for k := range api {
-				assert.True(t, strings.HasPrefix(string(k), "COSI_GCS_"))
-			}
 		})
 	}
 }
@@ -196,10 +191,6 @@ func TestGcsCredentialTranslator_RpcToApi(t *testing.T) {
 			s := GcsCredentialTranslator{}
 			api := s.RpcToApi(tt.rpc)
 			assert.Equal(t, tt.wantApi, api)
-
-			for k := range api {
-				assert.True(t, strings.HasPrefix(string(k), "COSI_GCS_"))
-			}
 		})
 	}
 }

--- a/internal/protocol/s3_test.go
+++ b/internal/protocol/s3_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package protocol
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -152,10 +151,6 @@ func TestS3BucketInfoTranslator_RpcToApi(t *testing.T) {
 			s := S3BucketInfoTranslator{}
 			api := s.RpcToApi(tt.rpc)
 			assert.Equal(t, tt.wantApi, api)
-
-			for k := range api {
-				assert.True(t, strings.HasPrefix(string(k), "COSI_S3_"))
-			}
 		})
 	}
 }
@@ -234,10 +229,6 @@ func TestS3CredentialTranslator_RpcToApi(t *testing.T) {
 			s := S3CredentialTranslator{}
 			api := s.RpcToApi(tt.rpc)
 			assert.Equal(t, tt.wantApi, api)
-
-			for k := range api {
-				assert.True(t, strings.HasPrefix(string(k), "COSI_S3_"))
-			}
 		})
 	}
 }

--- a/sidecar/internal/translator/translator_test.go
+++ b/sidecar/internal/translator/translator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package translator
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,16 +27,16 @@ import (
 
 func TestTranslateBucketInfo(t *testing.T) {
 	tests := []struct {
-		name                string // description of this test case
-		pbi                 *cosiproto.ObjectProtocolAndBucketInfo
-		validation          *ValidationConfig
-		wantProtos          []cosiapi.ObjectProtocol
-		wantInfoVarPrefixes []string
-		wantErr             string
+		name       string // description of this test case
+		pbi        *cosiproto.ObjectProtocolAndBucketInfo
+		validation *ValidationConfig
+		wantProtos []cosiapi.ObjectProtocol
+		wantInfo   map[string]string
+		wantErr    string
 	}{
 		{"no info, no validation",
 			&cosiproto.ObjectProtocolAndBucketInfo{}, nil,
-			[]cosiapi.ObjectProtocol{}, []string{}, "",
+			[]cosiapi.ObjectProtocol{}, map[string]string{}, "",
 		},
 		{"no info, validate S3",
 			&cosiproto.ObjectProtocolAndBucketInfo{},
@@ -59,11 +58,12 @@ func TestTranslateBucketInfo(t *testing.T) {
 				S3: &cosiproto.S3BucketInfo{},
 			},
 			nil, // no validation
-			[]cosiapi.ObjectProtocol{
-				cosiapi.ObjectProtocolS3,
-			},
-			[]string{
-				"COSI_S3_",
+			[]cosiapi.ObjectProtocol{cosiapi.ObjectProtocolS3},
+			map[string]string{
+				string(cosiapi.BucketInfoVar_S3_BucketId):        "",
+				string(cosiapi.BucketInfoVar_S3_Endpoint):        "",
+				string(cosiapi.BucketInfoVar_S3_Region):          "",
+				string(cosiapi.BucketInfoVar_S3_AddressingStyle): "",
 			},
 			"",
 		},
@@ -89,11 +89,12 @@ func TestTranslateBucketInfo(t *testing.T) {
 				},
 			},
 			nil, // no validation
-			[]cosiapi.ObjectProtocol{
-				cosiapi.ObjectProtocolS3,
-			},
-			[]string{
-				"COSI_S3_",
+			[]cosiapi.ObjectProtocol{cosiapi.ObjectProtocolS3},
+			map[string]string{
+				string(cosiapi.BucketInfoVar_S3_BucketId):        "something",
+				string(cosiapi.BucketInfoVar_S3_Endpoint):        "cosi.corp.net",
+				string(cosiapi.BucketInfoVar_S3_Region):          "",
+				string(cosiapi.BucketInfoVar_S3_AddressingStyle): "",
 			},
 			"",
 		},
@@ -124,11 +125,9 @@ func TestTranslateBucketInfo(t *testing.T) {
 				Azure: &cosiproto.AzureBucketInfo{},
 			},
 			nil, // no validation
-			[]cosiapi.ObjectProtocol{
-				cosiapi.ObjectProtocolAzure,
-			},
-			[]string{
-				"COSI_AZURE_",
+			[]cosiapi.ObjectProtocol{cosiapi.ObjectProtocolAzure},
+			map[string]string{
+				string(cosiapi.BucketInfoVar_Azure_StorageAccount): "",
 			},
 			"",
 		},
@@ -146,11 +145,9 @@ func TestTranslateBucketInfo(t *testing.T) {
 				},
 			},
 			nil, // no validation
-			[]cosiapi.ObjectProtocol{
-				cosiapi.ObjectProtocolAzure,
-			},
-			[]string{
-				"COSI_AZURE_",
+			[]cosiapi.ObjectProtocol{cosiapi.ObjectProtocolAzure},
+			map[string]string{
+				string(cosiapi.BucketInfoVar_Azure_StorageAccount): "something",
 			},
 			"",
 		},
@@ -168,11 +165,10 @@ func TestTranslateBucketInfo(t *testing.T) {
 				Gcs: &cosiproto.GcsBucketInfo{},
 			},
 			nil, // no validation
-			[]cosiapi.ObjectProtocol{
-				cosiapi.ObjectProtocolGcs,
-			},
-			[]string{
-				"COSI_GCS_",
+			[]cosiapi.ObjectProtocol{cosiapi.ObjectProtocolGcs},
+			map[string]string{
+				string(cosiapi.BucketInfoVar_GCS_BucketName): "",
+				string(cosiapi.BucketInfoVar_GCS_ProjectId):  "",
 			},
 			"",
 		},
@@ -190,11 +186,10 @@ func TestTranslateBucketInfo(t *testing.T) {
 				},
 			},
 			nil, // no validation
-			[]cosiapi.ObjectProtocol{
-				cosiapi.ObjectProtocolGcs,
-			},
-			[]string{
-				"COSI_GCS_",
+			[]cosiapi.ObjectProtocol{cosiapi.ObjectProtocolGcs},
+			map[string]string{
+				string(cosiapi.BucketInfoVar_GCS_BucketName): "something",
+				string(cosiapi.BucketInfoVar_GCS_ProjectId):  "",
 			},
 			"",
 		},
@@ -220,10 +215,13 @@ func TestTranslateBucketInfo(t *testing.T) {
 				cosiapi.ObjectProtocolAzure,
 				cosiapi.ObjectProtocolGcs,
 			},
-			[]string{
-				"COSI_S3_",
-				"COSI_AZURE_",
-				"COSI_GCS_",
+			map[string]string{
+				string(cosiapi.BucketInfoVar_S3_BucketId):          "",
+				string(cosiapi.BucketInfoVar_S3_Endpoint):          "",
+				string(cosiapi.BucketInfoVar_S3_Region):            "",
+				string(cosiapi.BucketInfoVar_S3_AddressingStyle):   "",
+				string(cosiapi.BucketInfoVar_Azure_StorageAccount): "",
+				string(cosiapi.BucketInfoVar_GCS_ProjectId):        "",
 			},
 			"",
 		},
@@ -272,10 +270,13 @@ func TestTranslateBucketInfo(t *testing.T) {
 				cosiapi.ObjectProtocolAzure,
 				cosiapi.ObjectProtocolGcs,
 			},
-			[]string{
-				"COSI_S3_",
-				"COSI_AZURE_",
-				"COSI_GCS_",
+			map[string]string{
+				string(cosiapi.BucketInfoVar_S3_BucketId):          "something",
+				string(cosiapi.BucketInfoVar_S3_Endpoint):          "",
+				string(cosiapi.BucketInfoVar_S3_Region):            "",
+				string(cosiapi.BucketInfoVar_S3_AddressingStyle):   "",
+				string(cosiapi.BucketInfoVar_Azure_StorageAccount): "acct",
+				string(cosiapi.BucketInfoVar_GCS_ProjectId):        "",
 			},
 			"",
 		},
@@ -335,24 +336,10 @@ func TestTranslateBucketInfo(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr)
 			}
 			assert.Equal(t, tt.wantProtos, protos)
-			// If we check the exact results of details.allProtoBucketInfo, we will tie the unit
-			// tests to the specific implementation of bucket info translators, tested elsewhere.
-			// Instead, check only that prefixes match what we expect.
-			if len(tt.wantProtos) > 0 {
-				assert.NotZero(t, len(infoVars))
+			if tt.wantErr == "" {
+				assert.Equal(t, tt.wantInfo, infoVars)
 			} else {
-				assert.Zero(t, len(infoVars))
-			}
-			// t.Log("got info map:", infoVars)
-			for _, p := range tt.wantInfoVarPrefixes {
-				found := false
-				for k := range infoVars {
-					assert.True(t, strings.HasPrefix(k, "COSI_")) // all vars must be prefixed COSI_
-					if strings.HasPrefix(k, p) {
-						found = true
-					}
-				}
-				assert.Truef(t, found, "prefix %q not found in %v keys", p, infoVars)
+				assert.Nil(t, infoVars)
 			}
 		})
 	}
@@ -360,40 +347,88 @@ func TestTranslateBucketInfo(t *testing.T) {
 
 func TestTranslateCredentials(t *testing.T) {
 	tests := []struct {
-		name                string // description of this test case
-		pbi                 *cosiproto.CredentialInfo
-		validation          ValidationConfig
-		wantInfoVarPrefixes []string
-		wantErr             string
+		name       string // description of this test case
+		pbi        *cosiproto.CredentialInfo
+		validation ValidationConfig
+		wantCreds  map[string]string
+		wantErr    string
 	}{
+		{"s3 valid, validate S3",
+			&cosiproto.CredentialInfo{
+				S3: &cosiproto.S3CredentialInfo{
+					AccessKeyId:     "accesskey",
+					AccessSecretKey: "secretkey",
+				},
+			},
+			ValidationConfig{cosiapi.ObjectProtocolS3, cosiapi.BucketAccessAuthenticationTypeKey},
+			map[string]string{
+				string(cosiapi.CredentialVar_S3_AccessKeyId):     "accesskey",
+				string(cosiapi.CredentialVar_S3_AccessSecretKey): "secretkey",
+			},
+			"",
+		},
+		{"azure valid, validate Azure",
+			&cosiproto.CredentialInfo{
+				Azure: &cosiproto.AzureCredentialInfo{
+					AccessToken: "token",
+				},
+			},
+			ValidationConfig{cosiapi.ObjectProtocolAzure, cosiapi.BucketAccessAuthenticationTypeKey},
+			map[string]string{
+				string(cosiapi.CredentialVar_Azure_AccessToken):     "token",
+				string(cosiapi.CredentialVar_Azure_ExpiryTimestamp): "",
+			},
+			"",
+		},
+		{"GCS key valid, validate GCS",
+			&cosiproto.CredentialInfo{
+				Gcs: &cosiproto.GcsCredentialInfo{
+					AccessId:     "accessId",
+					AccessSecret: "accessSecret",
+				},
+			},
+			ValidationConfig{cosiapi.ObjectProtocolGcs, cosiapi.BucketAccessAuthenticationTypeKey},
+			map[string]string{
+				string(cosiapi.CredentialVar_GCS_AccessId):       "accessId",
+				string(cosiapi.CredentialVar_GCS_AccessSecret):   "accessSecret",
+				string(cosiapi.CredentialVar_GCS_PrivateKeyName): "",
+				string(cosiapi.CredentialVar_GCS_ServiceAccount): "",
+			},
+			"",
+		},
 		{"no info, validate S3",
 			&cosiproto.CredentialInfo{},
 			ValidationConfig{cosiapi.ObjectProtocolS3, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `missing response for expected "S3" protocol`,
+			nil,
+			`missing response for expected "S3" protocol`,
 		},
 		{"no info, validate Azure",
 			&cosiproto.CredentialInfo{},
 			ValidationConfig{cosiapi.ObjectProtocolAzure, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `missing response for expected "Azure" protocol`,
+			nil,
+			`missing response for expected "Azure" protocol`,
 		},
 		{"no info, validate GCS",
 			&cosiproto.CredentialInfo{},
 			ValidationConfig{cosiapi.ObjectProtocolGcs, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `missing response for expected "GCS" protocol`,
+			nil,
+			`missing response for expected "GCS" protocol`,
 		},
 		{"s3 empty, validate S3",
 			&cosiproto.CredentialInfo{
 				S3: &cosiproto.S3CredentialInfo{},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolS3, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, "errors translating S3 bucket credentials",
+			nil,
+			"errors translating S3 bucket credentials",
 		},
 		{"s3 empty, validate Azure",
 			&cosiproto.CredentialInfo{
 				S3: &cosiproto.S3CredentialInfo{},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolAzure, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `missing response for expected "Azure" protocol`,
+			nil,
+			`missing response for expected "Azure" protocol`,
 		},
 		{"s3 non-empty, validate S3",
 			&cosiproto.CredentialInfo{
@@ -403,7 +438,8 @@ func TestTranslateCredentials(t *testing.T) {
 				},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolS3, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, "errors translating S3 bucket credentials",
+			nil,
+			"errors translating S3 bucket credentials",
 		},
 		{"s3 non-empty, validate GCS",
 			&cosiproto.CredentialInfo{
@@ -413,14 +449,16 @@ func TestTranslateCredentials(t *testing.T) {
 				},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolGcs, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `missing response for expected "GCS" protocol`,
+			nil,
+			`missing response for expected "GCS" protocol`,
 		},
 		{"azure empty, validate Azure",
 			&cosiproto.CredentialInfo{
 				Azure: &cosiproto.AzureCredentialInfo{},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolAzure, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, "errors translating Azure bucket credentials",
+			nil,
+			"errors translating Azure bucket credentials",
 		},
 		{"azure non-empty, validate Azure",
 			&cosiproto.CredentialInfo{
@@ -429,14 +467,16 @@ func TestTranslateCredentials(t *testing.T) {
 				},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolAzure, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, "errors translating Azure bucket credentials",
+			nil,
+			"errors translating Azure bucket credentials",
 		},
 		{"GCS empty, validate GCS",
 			&cosiproto.CredentialInfo{
 				Gcs: &cosiproto.GcsCredentialInfo{},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolGcs, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, "errors translating GCS bucket credentials",
+			nil,
+			"errors translating GCS bucket credentials",
 		},
 		{"GCS non-empty, validate GCS",
 			&cosiproto.CredentialInfo{
@@ -446,7 +486,8 @@ func TestTranslateCredentials(t *testing.T) {
 				},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolGcs, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, "errors translating GCS bucket credentials",
+			nil,
+			"errors translating GCS bucket credentials",
 		},
 		{"s3+azure+GCS empty, validate S3",
 			&cosiproto.CredentialInfo{
@@ -455,7 +496,8 @@ func TestTranslateCredentials(t *testing.T) {
 				Gcs:   &cosiproto.GcsCredentialInfo{},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolS3, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `only "S3" protocol is expected`,
+			nil,
+			`only "S3" protocol is expected`,
 		},
 		{"s3+azure+GCS empty, validate Azure",
 			&cosiproto.CredentialInfo{
@@ -464,7 +506,8 @@ func TestTranslateCredentials(t *testing.T) {
 				Gcs:   &cosiproto.GcsCredentialInfo{},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolAzure, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `only "Azure" protocol is expected`,
+			nil,
+			`only "Azure" protocol is expected`,
 		},
 		{"s3+azure+GCS empty, validate GCS",
 			&cosiproto.CredentialInfo{
@@ -473,7 +516,8 @@ func TestTranslateCredentials(t *testing.T) {
 				Gcs:   &cosiproto.GcsCredentialInfo{},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolGcs, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `only "GCS" protocol is expected`,
+			nil,
+			`only "GCS" protocol is expected`,
 		},
 		{"s3+azure+GCS non-empty, validate S3",
 			&cosiproto.CredentialInfo{
@@ -488,7 +532,8 @@ func TestTranslateCredentials(t *testing.T) {
 				},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolS3, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `only "S3" protocol is expected`,
+			nil,
+			`only "S3" protocol is expected`,
 		},
 		{"s3+azure+GCS non-empty, validate Azure",
 			&cosiproto.CredentialInfo{
@@ -503,7 +548,8 @@ func TestTranslateCredentials(t *testing.T) {
 				},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolAzure, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `only "Azure" protocol is expected`,
+			nil,
+			`only "Azure" protocol is expected`,
 		},
 		{"s3+azure+GCS non-empty, validate GCS",
 			&cosiproto.CredentialInfo{
@@ -518,7 +564,8 @@ func TestTranslateCredentials(t *testing.T) {
 				},
 			},
 			ValidationConfig{cosiapi.ObjectProtocolGcs, cosiapi.BucketAccessAuthenticationTypeKey},
-			nil, `only "GCS" protocol is expected`,
+			nil,
+			`only "GCS" protocol is expected`,
 		},
 	}
 	for _, tt := range tests {
@@ -530,22 +577,10 @@ func TestTranslateCredentials(t *testing.T) {
 				t.Log("got error:", err)
 				assert.ErrorContains(t, err, tt.wantErr)
 			}
-			// If we check the exact results of details.allProtoBucketInfo, we will tie the unit
-			// tests to the specific implementation of bucket info translators, tested elsewhere.
-			// Instead, check only that prefixes match what we expect.
 			if tt.wantErr == "" {
-				assert.NotZero(t, len(creds))
-			}
-			// t.Log("got info map:", infoVars)
-			for _, p := range tt.wantInfoVarPrefixes {
-				found := false
-				for k := range creds {
-					assert.True(t, strings.HasPrefix(k, "COSI_")) // all vars must be prefixed COSI_
-					if strings.HasPrefix(k, p) {
-						found = true
-					}
-				}
-				assert.Truef(t, found, "prefix %q not found in %v keys", p, creds)
+				assert.Equal(t, tt.wantCreds, creds)
+			} else {
+				assert.Nil(t, creds)
 			}
 		})
 	}

--- a/sidecar/pkg/reconciler/bucket_test.go
+++ b/sidecar/pkg/reconciler/bucket_test.go
@@ -19,7 +19,6 @@ package reconciler
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -135,11 +134,12 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 			[]cosiapi.ObjectProtocol{cosiapi.ObjectProtocolS3},
 			bucket.Status.Protocols,
 		)
-		assert.NotEmpty(t, bucket.Status.BucketInfo)
-		assert.Equal(t, "corp-cosi-bc-qwerty", bucket.Status.BucketInfo["COSI_S3_BUCKET_ID"])
-		for k := range bucket.Status.BucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_S3_"))
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_S3_BucketId):        "corp-cosi-bc-qwerty",
+			string(cosiapi.BucketInfoVar_S3_Endpoint):        "s3.corp.net",
+			string(cosiapi.BucketInfoVar_S3_Region):          "us-east-1",
+			string(cosiapi.BucketInfoVar_S3_AddressingStyle): "path",
+		}, bucket.Status.BucketInfo)
 
 		t.Log("run Reconcile() a second time to ensure nothing is modified")
 
@@ -532,10 +532,12 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 		assert.True(t, *bucket.Status.ReadyToUse)
 		assert.Equal(t, "static-bucket", bucket.Status.BucketID)
 		assert.Equal(t, []cosiapi.ObjectProtocol{cosiapi.ObjectProtocolS3}, bucket.Status.Protocols)
-		assert.NotEmpty(t, bucket.Status.BucketInfo)
-		for k := range bucket.Status.BucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_S3_"))
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_S3_BucketId):        "static-bucket",
+			string(cosiapi.BucketInfoVar_S3_Endpoint):        "s3.corp.net",
+			string(cosiapi.BucketInfoVar_S3_Region):          "us-east-1",
+			string(cosiapi.BucketInfoVar_S3_AddressingStyle): "path",
+		}, bucket.Status.BucketInfo)
 
 		t.Log("run Reconcile() a second time to ensure nothing is modified")
 
@@ -911,15 +913,12 @@ func TestBucketReconciler_dynamicProvision(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "bc-qwerty", details.bucketId)
 		assert.Equal(t, []cosiapi.ObjectProtocol{cosiapi.ObjectProtocolS3}, details.supportedProtos)
-		// If we check the exact results of details.allProtoBucketInfo, we will tie the unit tests
-		// to the specific implementation of the S3 bucket info translator, tested elsewhere.
-		// Instead, check only COSI_S3_BUCKET_ID which is unlikely to change in the future, and
-		// check that all info is prefixed `COSI_S3_`.
-		assert.NotEmpty(t, details.allProtoBucketInfo)
-		assert.Equal(t, "backend-bc-qwerty", details.allProtoBucketInfo[string(cosiapi.BucketInfoVar_S3_BucketId)])
-		for k := range details.allProtoBucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_S3_"))
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_S3_BucketId):        "backend-bc-qwerty",
+			string(cosiapi.BucketInfoVar_S3_Endpoint):        "s3.corp.net",
+			string(cosiapi.BucketInfoVar_S3_Region):          "us-east-1",
+			string(cosiapi.BucketInfoVar_S3_AddressingStyle): "path",
+		}, details.allProtoBucketInfo)
 		assert.Equal(t, inputParams, requestParams)
 	})
 
@@ -1179,11 +1178,12 @@ func TestBucketReconciler_dynamicProvision(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "bc-qwerty", details.bucketId)
 		assert.Equal(t, []cosiapi.ObjectProtocol{cosiapi.ObjectProtocolS3}, details.supportedProtos)
-		assert.NotEmpty(t, details.allProtoBucketInfo) // bucket info should be present
-		for k, v := range details.allProtoBucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_S3_"))
-			assert.Empty(t, v) // but all info will be empty string
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_S3_BucketId):        "",
+			string(cosiapi.BucketInfoVar_S3_Endpoint):        "",
+			string(cosiapi.BucketInfoVar_S3_Region):          "",
+			string(cosiapi.BucketInfoVar_S3_AddressingStyle): "",
+		}, details.allProtoBucketInfo)
 	})
 
 	t.Run("valid driver, empty Azure proto response", func(t *testing.T) {
@@ -1226,11 +1226,9 @@ func TestBucketReconciler_dynamicProvision(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "bc-qwerty", details.bucketId)
 		assert.Equal(t, []cosiapi.ObjectProtocol{cosiapi.ObjectProtocolAzure}, details.supportedProtos)
-		assert.NotEmpty(t, details.allProtoBucketInfo) // bucket info should be present
-		for k, v := range details.allProtoBucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_AZURE_"))
-			assert.Empty(t, v) // but all info will be empty string
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_Azure_StorageAccount): "",
+		}, details.allProtoBucketInfo)
 	})
 
 	t.Run("valid driver, empty GCS proto response", func(t *testing.T) {
@@ -1273,11 +1271,10 @@ func TestBucketReconciler_dynamicProvision(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "bc-qwerty", details.bucketId)
 		assert.Equal(t, []cosiapi.ObjectProtocol{cosiapi.ObjectProtocolGcs}, details.supportedProtos)
-		assert.NotEmpty(t, details.allProtoBucketInfo) // bucket info should be present
-		for k, v := range details.allProtoBucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_GCS_"))
-			assert.Empty(t, v) // but all info will be empty string
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_GCS_BucketName): "",
+			string(cosiapi.BucketInfoVar_GCS_ProjectId):  "",
+		}, details.allProtoBucketInfo)
 	})
 
 	t.Run("valid driver, empty S3+Azure proto response", func(t *testing.T) {
@@ -1330,11 +1327,13 @@ func TestBucketReconciler_dynamicProvision(t *testing.T) {
 			},
 			details.supportedProtos,
 		)
-		assert.NotEmpty(t, details.allProtoBucketInfo) // bucket info should be present
-		for k, v := range details.allProtoBucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_S3_") || strings.HasPrefix(k, "COSI_AZURE_"))
-			assert.Empty(t, v) // but all info will be empty string
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_S3_BucketId):          "",
+			string(cosiapi.BucketInfoVar_S3_Endpoint):          "",
+			string(cosiapi.BucketInfoVar_S3_Region):            "",
+			string(cosiapi.BucketInfoVar_S3_AddressingStyle):   "",
+			string(cosiapi.BucketInfoVar_Azure_StorageAccount): "",
+		}, details.allProtoBucketInfo)
 	})
 }
 
@@ -1397,11 +1396,12 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "static-bucket", details.bucketId)
 		assert.Equal(t, []cosiapi.ObjectProtocol{cosiapi.ObjectProtocolS3}, details.supportedProtos)
-		assert.NotEmpty(t, details.allProtoBucketInfo)
-		assert.Equal(t, "static-bucket", details.allProtoBucketInfo[string(cosiapi.BucketInfoVar_S3_BucketId)])
-		for k := range details.allProtoBucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_S3_"))
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_S3_BucketId):        "static-bucket",
+			string(cosiapi.BucketInfoVar_S3_Endpoint):        "s3.corp.net",
+			string(cosiapi.BucketInfoVar_S3_Region):          "us-east-1",
+			string(cosiapi.BucketInfoVar_S3_AddressingStyle): "path",
+		}, details.allProtoBucketInfo)
 		assert.Equal(t, inputParams, requestParams)
 	})
 
@@ -1707,11 +1707,12 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "static-bucket", details.bucketId)
 		assert.Equal(t, []cosiapi.ObjectProtocol{cosiapi.ObjectProtocolS3}, details.supportedProtos)
-		assert.NotEmpty(t, details.allProtoBucketInfo)
-		for k, v := range details.allProtoBucketInfo {
-			assert.True(t, strings.HasPrefix(k, "COSI_S3_"))
-			assert.Empty(t, v)
-		}
+		assert.Equal(t, map[string]string{
+			string(cosiapi.BucketInfoVar_S3_BucketId):        "",
+			string(cosiapi.BucketInfoVar_S3_Endpoint):        "",
+			string(cosiapi.BucketInfoVar_S3_Region):          "",
+			string(cosiapi.BucketInfoVar_S3_AddressingStyle): "",
+		}, details.allProtoBucketInfo)
 	})
 }
 

--- a/vendor/sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2/bucket_types.go
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2/bucket_types.go
@@ -165,9 +165,9 @@ type BucketStatus struct {
 	// +kubebuilder:validation:MaxItems=3
 	Protocols []ObjectProtocol `json:"protocols,omitempty"`
 
-	// bucketInfo contains info about the bucket reported by the driver, rendered in the same
-	// COSI_<PROTOCOL>_<KEY> format used for the BucketAccess Secret.
-	// e.g., COSI_S3_ENDPOINT, COSI_AZURE_STORAGE_ACCOUNT.
+	// bucketInfo contains info about the bucket reported by the driver, rendered in the
+	// well-known env var key format used for the BucketAccess Secret.
+	// e.g., AWS_ENDPOINT_URL, AZURE_STORAGE_ACCOUNT.
 	// This should not contain any sensitive information.
 	// +optional
 	// +kubebuilder:validation:MinProperties=1

--- a/vendor/sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2/protocols.go
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2/protocols.go
@@ -37,24 +37,24 @@ const (
 	ObjectProtocolGcs ObjectProtocol = "GCS"
 )
 
-// A CosiEnvVar defines a COSI environment variable that contains backend bucket or access info.
+// A CosiEnvVar defines an environment variable that contains backend bucket or access info.
 // Vars marked "Required" will be present with non-empty values in BucketAccess Secrets.
 // Some required vars may only be required in certain contexts, like when a specific
 // AuthenticationType is used.
 // Some vars are only relevant for specific protocols.
 // Non-relevant vars will not be present, even when marked "Required".
 // Vars are used as data keys in BucketAccess Secrets.
-// Vars must be all-caps and must begin with `COSI_`.
+// Vars must be all-caps.
 type CosiEnvVar string
 
 // A BucketInfoVar defines a protocol-specific COSI environment variable that contains backend
 // bucket info.
-// All protocol-specific vars include the all-caps protocol name after `COSI_`. E.g., `COSI_AZURE_`.
+// Protocol-specific vars use well-known ecosystem names when available.
 type BucketInfoVar CosiEnvVar
 
 // A CredentialVar defines a protocol-specific COSI environment variable that contains backend
 // bucket access credential info.
-// All protocol-specific vars include the all-caps protocol name after `COSI_`. E.g., `COSI_AZURE_`.
+// Protocol-specific vars use well-known ecosystem names when available.
 type CredentialVar CosiEnvVar
 
 const (
@@ -73,26 +73,26 @@ const (
 // bucket info vars
 const (
 	// Required. The S3 bucket ID as used by clients.
-	BucketInfoVar_S3_BucketId BucketInfoVar = "COSI_S3_BUCKET_ID"
+	BucketInfoVar_S3_BucketId BucketInfoVar = "BUCKET_NAME"
 
 	// Required. The S3 endpoint for the bucket.
-	BucketInfoVar_S3_Endpoint BucketInfoVar = "COSI_S3_ENDPOINT"
+	BucketInfoVar_S3_Endpoint BucketInfoVar = "AWS_ENDPOINT_URL"
 
 	// Required. The S3 region for the bucket.
-	BucketInfoVar_S3_Region BucketInfoVar = "COSI_S3_REGION"
+	BucketInfoVar_S3_Region BucketInfoVar = "AWS_DEFAULT_REGION"
 
 	// Required. The S3 addressing style. One of `path` or `virtual`.
 	// See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html.
-	BucketInfoVar_S3_AddressingStyle BucketInfoVar = "COSI_S3_ADDRESSING_STYLE"
+	BucketInfoVar_S3_AddressingStyle BucketInfoVar = "AWS_S3_ADDRESSING_STYLE"
 )
 
 // nolint:gosec // credential vars, not hardcoded credentials
 const (
 	// Required for `AuthenticationType=Key`. The S3 access key ID.
-	CredentialVar_S3_AccessKeyId CredentialVar = "COSI_S3_ACCESS_KEY_ID" // nolint:gosec // no a cred
+	CredentialVar_S3_AccessKeyId CredentialVar = "AWS_ACCESS_KEY_ID" // nolint:gosec // no a cred
 
 	// Required for `AuthenticationType=Key`. The S3 access secret key.
-	CredentialVar_S3_AccessSecretKey CredentialVar = "COSI_S3_ACCESS_SECRET_KEY" // nolint:gosec // no a cred
+	CredentialVar_S3_AccessSecretKey CredentialVar = "AWS_SECRET_ACCESS_KEY" // nolint:gosec // no a cred
 )
 
 /*
@@ -102,7 +102,7 @@ const (
 // bucket info vars
 const (
 	// Required. The ID of the Azure storage account.
-	BucketInfoVar_Azure_StorageAccount BucketInfoVar = "COSI_AZURE_STORAGE_ACCOUNT"
+	BucketInfoVar_Azure_StorageAccount BucketInfoVar = "AZURE_STORAGE_ACCOUNT"
 )
 
 // nolint:gosec // credential vars, not hardcoded credentials
@@ -110,11 +110,11 @@ const (
 	// Required for `AuthenticationType=Key`. Azure SAS access token.
 	// Note that this includes the resource URI as well as token in its definition.
 	// See: https://learn.microsoft.com/en-us/azure/storage/common/media/storage-sas-overview/sas-storage-uri.svg
-	CredentialVar_Azure_AccessToken CredentialVar = "COSI_AZURE_ACCESS_TOKEN"
+	CredentialVar_Azure_AccessToken CredentialVar = "AZURE_STORAGE_SAS_TOKEN"
 
 	// Optional. The timestamp when access will expire.
 	// Empty if unset. Otherwise, date+time in ISO 8601 format.
-	CredentialVar_Azure_ExpiryTimestamp CredentialVar = "COSI_AZURE_EXPIRY_TIMESTAMP"
+	CredentialVar_Azure_ExpiryTimestamp CredentialVar = "AZURE_STORAGE_SAS_TOKEN_EXPIRY_TIMESTAMP"
 )
 
 /*
@@ -124,23 +124,23 @@ const (
 // bucket info vars
 const (
 	// Required. The GCS project ID.
-	BucketInfoVar_GCS_ProjectId BucketInfoVar = "COSI_GCS_PROJECT_ID"
+	BucketInfoVar_GCS_ProjectId BucketInfoVar = "PROJECT_ID"
 
 	// Required. GCS bucket name as used by clients.
-	BucketInfoVar_GCS_BucketName BucketInfoVar = "COSI_GCS_BUCKET_NAME"
+	BucketInfoVar_GCS_BucketName BucketInfoVar = "BUCKET_NAME"
 )
 
 // nolint:gosec // credential vars, not hardcoded credentials
 const (
 	// Required for `AuthenticationType=Key`. HMAC access ID.
-	CredentialVar_GCS_AccessId CredentialVar = "COSI_GCS_ACCESS_ID"
+	CredentialVar_GCS_AccessId CredentialVar = "HMAC_ACCESS_ID"
 
 	// Required for `AuthenticationType=Key`. HMAC secret.
-	CredentialVar_GCS_AccessSecret CredentialVar = "COSI_GCS_ACCESS_SECRET"
+	CredentialVar_GCS_AccessSecret CredentialVar = "HMAC_SECRET"
 
 	// GCS private key name.
-	CredentialVar_GCS_PrivateKeyName CredentialVar = "COSI_GCS_PRIVATE_KEY_NAME"
+	CredentialVar_GCS_PrivateKeyName CredentialVar = "PRIVATE_KEY_ID"
 
 	// GCS service account name.
-	CredentialVar_GCS_ServiceAccount CredentialVar = "COSI_GCS_SERVICE_ACCOUNT"
+	CredentialVar_GCS_ServiceAccount CredentialVar = "SERVICE_ACCOUNT_NAME"
 )


### PR DESCRIPTION
https://github.com/kubernetes-sigs/container-object-storage-interface/issues/165

Instead of `COSI_<PROTO>_X_Y_Z` env vars, use well-known proto config env vars, when available.
Ref: https://github.com/kubernetes/enhancements/pull/4599#pullrequestreview-3764495114