### PR TITLE
Requeue prerequisite waits steadily instead of via error backoff

### DIFF
--- a/controller/pkg/reconciler/bucketaccess.go
+++ b/controller/pkg/reconciler/bucketaccess.go
@@ -40,6 +40,10 @@ import (
 	cosipredicate "sigs.k8s.io/container-object-storage-interface/internal/predicate"
 )
 
+// waitingRequeueDelay is the steady poll interval used when a reconcile is waiting on a
+// prerequisite resource (WaitingError). See internal/errors.WaitingError for rationale.
+const waitingRequeueDelay = 30 * time.Second
+
 // BucketAccessReconciler reconciles a BucketAccess object
 type BucketAccessReconciler struct {
 	client.Client
@@ -91,6 +95,11 @@ func (r *BucketAccessReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		if errors.Is(err, cosierr.NonRetryableError(nil)) {
 			return reconcile.Result{}, reconcile.TerminalError(err)
+		}
+		if errors.Is(err, cosierr.WaitingError(nil)) {
+			// Steady poll while waiting on prerequisites. Returning success resets the
+			// rate limiter so the wait never inherits a large backoff delay.
+			return reconcile.Result{RequeueAfter: waitingRequeueDelay}, nil
 		}
 		return reconcile.Result{}, err
 	}
@@ -226,10 +235,12 @@ func (r *BucketAccessReconciler) reconcile(
 	waitlist := waitingOnBucketClaims(claimsByName, bucketsByClaimName)
 	if len(waitlist) > 0 {
 		logger.Error(nil, "waiting for prerequisites before provisioning access", "waitlist", waitlist)
-		// TODO: for now, return an error and allow the controller to exponential backoff until we
-		// are done waiting on the resources. in the future, optimize this by adding a bucketclaim
-		// reconciler that enqueues requests for BucketClaims when they finish provisioning.
-		return fmt.Errorf("waiting for prerequisites before provisioning access: %v", waitlist)
+		// A WaitingError maps to a steady RequeueAfter poll rather than exponential backoff:
+		// backoff caps at ~17m, so a slow-provisioning Bucket could otherwise leave this access
+		// unprocessed long after the Bucket became ready. In the future, optimize this by adding
+		// a watch that enqueues BucketAccesses when a referenced BucketClaim finishes provisioning.
+		return cosierr.WaitingError(
+			fmt.Errorf("waiting for prerequisites before provisioning access: %v", waitlist))
 	}
 
 	accessedBuckets, err := compileAccessedBuckets(access.Spec.BucketClaims, bucketsByClaimName)

--- a/controller/pkg/reconciler/bucketclaim.go
+++ b/controller/pkg/reconciler/bucketclaim.go
@@ -84,6 +84,11 @@ func (r *BucketClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if errors.Is(err, cosierr.NonRetryableError(nil)) {
 			return reconcile.Result{}, reconcile.TerminalError(err)
 		}
+		if errors.Is(err, cosierr.WaitingError(nil)) {
+			// Steady poll while waiting on the Bucket. Returning success resets the
+			// rate limiter so the wait never inherits a large backoff delay.
+			return reconcile.Result{RequeueAfter: waitingRequeueDelay}, nil
+		}
 		return reconcile.Result{}, err
 	}
 
@@ -217,9 +222,10 @@ func (r *BucketClaimReconciler) reconcile(ctx context.Context, logger logr.Logge
 
 	if bucket.Status.BucketID == "" {
 		// TODO: In the future, set up Bucket watcher to enqueue this BucketClaim when the Bucket
-		// is updated. For now, return error to requeue with backoff.
+		// is updated. For now, return a WaitingError to requeue on a steady poll (plain-error
+		// backoff caps high enough to strand the claim long after the Bucket is ready).
 		logger.Info("waiting for Bucket to be provisioned")
-		return fmt.Errorf("waiting for Bucket to be provisioned")
+		return cosierr.WaitingError(fmt.Errorf("waiting for Bucket to be provisioned"))
 	}
 
 	readyToUse := ptr.Deref(bucket.Status.ReadyToUse, false)
@@ -302,7 +308,7 @@ func (r *BucketClaimReconciler) reconcileDelete(
 		if !bucket.DeletionTimestamp.IsZero() {
 			logger.Info("still waiting for Bucket to be deleted")
 			// TODO: return nil when Bucket watcher is set up
-			return fmt.Errorf("still waiting for Bucket to be deleted")
+			return cosierr.WaitingError(fmt.Errorf("still waiting for Bucket to be deleted"))
 		}
 
 		if err := r.applyBucketClaimIsDeletingAnnotation(ctx, logger, bucket); err != nil {
@@ -316,7 +322,7 @@ func (r *BucketClaimReconciler) reconcileDelete(
 
 		logger.Info("waiting for Bucket to be deleted")
 		// TODO: return nil when Bucket watcher is set up
-		return fmt.Errorf("waiting for Bucket to be deleted")
+		return cosierr.WaitingError(fmt.Errorf("waiting for Bucket to be deleted"))
 		// once Bucket is deleted, a future reconcile will remove the BucketClaim finalizer
 
 	default:

--- a/controller/pkg/reconciler/reconciler_test/bucketaccess_test.go
+++ b/controller/pkg/reconciler/reconciler_test/bucketaccess_test.go
@@ -18,6 +18,7 @@ package reconciler_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -311,9 +312,9 @@ func TestBucketAccessReconcile(t *testing.T) {
 		require.True(t, *rwClaim.Status.ReadyToUse)
 
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseAccess)})
-		assert.Error(t, err)
-		assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
-		assert.Empty(t, res)
+		// Waiting on prerequisites is a steady poll (WaitingError -> RequeueAfter), not an error.
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 30 * time.Second}, res)
 
 		access, rwClaim, roClaim := getAccessResources(bootstrapped)
 
@@ -374,9 +375,9 @@ func TestBucketAccessReconcile(t *testing.T) {
 		require.True(t, *roClaim.Status.ReadyToUse)
 
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseAccess)})
-		assert.Error(t, err)
-		assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
-		assert.Empty(t, res)
+		// Waiting on prerequisites is a steady poll (WaitingError -> RequeueAfter), not an error.
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 30 * time.Second}, res)
 
 		access, rwClaim, roClaim := getAccessResources(bootstrapped)
 

--- a/controller/pkg/reconciler/reconciler_test/bucketclaim_test.go
+++ b/controller/pkg/reconciler/reconciler_test/bucketclaim_test.go
@@ -18,6 +18,7 @@ package reconciler_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -177,10 +178,10 @@ func dynamicInitializationTest(t *testing.T) (
 	ctx := bootstrapped.ContextWithLogger
 
 	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseDynamicClaim)})
-	assert.Error(t, err) // TODO: should be NoError when Bucket watcher is set up
-	assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
-	assert.ErrorContains(t, err, "waiting for Bucket to be provisioned")
-	assert.Empty(t, res)
+	// Waiting on the Bucket is a steady poll (WaitingError -> RequeueAfter), not an error.
+	// TODO: should requeue only on Bucket watch events when Bucket watcher is set up.
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{RequeueAfter: 30 * time.Second}, res)
 
 	claim, bucket, _ := getAllClaimResources(bootstrapped)
 
@@ -224,10 +225,10 @@ func staticInitializationTest(
 	ctx := bootstrapped.ContextWithLogger
 
 	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseStaticClaim)})
-	assert.Error(t, err) // TODO: should be NoError when Bucket watcher is set up
-	assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
-	assert.ErrorContains(t, err, "waiting for Bucket to be provisioned")
-	assert.Empty(t, res)
+	// Waiting on the Bucket is a steady poll (WaitingError -> RequeueAfter), not an error.
+	// TODO: should requeue only on Bucket watch events when Bucket watcher is set up.
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{RequeueAfter: 30 * time.Second}, res)
 
 	claim, dynamicBucket, staticBucket := getAllClaimResources(bootstrapped)
 
@@ -303,10 +304,10 @@ func deletionTestSuite(t *testing.T,
 		require.NoError(t, r.Delete(ctx, initClaim))
 
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseDynamicClaim)})
-		assert.Error(t, err) // TODO: should be NoError when Bucket watcher is set up
-		assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
-		assert.ErrorContains(t, err, "waiting for Bucket to be deleted")
-		assert.Empty(t, res)
+		// Waiting on Bucket deletion is a steady poll (WaitingError -> RequeueAfter), not an error.
+		// TODO: should requeue only on Bucket watch events when Bucket watcher is set up.
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{RequeueAfter: 30 * time.Second}, res)
 
 		claim, bucket := getClaimAndBucket(bootstrapped)
 
@@ -398,9 +399,10 @@ func TestBucketClaimReconcile(t *testing.T) {
 					require.NotNil(t, initBucket)
 
 					res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseDynamicClaim)})
-					assert.Error(t, err) // TODO: should be NoError when Bucket watcher is set up
-					assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
-					assert.Empty(t, res)
+					// Waiting on the Bucket is a steady poll (WaitingError -> RequeueAfter), not an error.
+					// TODO: should requeue only on Bucket watch events when Bucket watcher is set up.
+					assert.NoError(t, err)
+					assert.Equal(t, reconcile.Result{RequeueAfter: 30 * time.Second}, res)
 
 					claim, bucket := getClaimAndBucket(bootstrapped)
 
@@ -474,9 +476,10 @@ func TestBucketClaimReconcile(t *testing.T) {
 					initClaim, initBucket := getClaimAndBucket(bootstrapped)
 
 					res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseDynamicClaim)})
-					assert.Error(t, err) // TODO: should be NoError when Bucket watcher is set up
-					assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
-					assert.Empty(t, res)
+					// Waiting on the Bucket is a steady poll (WaitingError -> RequeueAfter), not an error.
+					// TODO: should requeue only on Bucket watch events when Bucket watcher is set up.
+					assert.NoError(t, err)
+					assert.Equal(t, reconcile.Result{RequeueAfter: 30 * time.Second}, res)
 
 					claim, bucket := getClaimAndBucket(bootstrapped)
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -19,6 +19,33 @@ package errors
 
 import "errors"
 
+// WaitingError is an error that indicates the reconcile is waiting on a prerequisite resource
+// to reach a desired state (e.g. a Bucket finishing provisioning or deleting). Reconcilers should
+// map it to a steady RequeueAfter poll instead of returning it as a plain error: plain-error
+// exponential backoff grows to a multi-minute cap, so a wait on a slow prerequisite can leave the
+// object unprocessed long after the prerequisite becomes ready.
+func WaitingError(wrapped error) error {
+	return &waitingError{err: wrapped}
+}
+
+type waitingError struct {
+	err error
+}
+
+func (we *waitingError) Error() string {
+	return we.err.Error()
+}
+
+// This function will return nil if we.err is nil.
+func (we *waitingError) Unwrap() error {
+	return we.err
+}
+
+func (we *waitingError) Is(target error) bool {
+	tp := &waitingError{}
+	return errors.As(target, &tp)
+}
+
 // NonRetryableError is an error that should not be retried but still treated as a reconcile error.
 func NonRetryableError(wrapped error) error {
 	return &nonRetryableError{err: wrapped}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The central controller handles every prerequisite wait (BucketAccess waiting on BucketClaims, BucketClaim waiting on Bucket provisioning, and both deletion waits) by returning a plain error, relying on controller-runtime's exponential backoff for the retry. Backoff caps at ~16m40s and the generation-based event filters drop the update events that could re-trigger reconcile sooner — so an object whose prerequisite was briefly slow can stay unreconciled ~17 minutes after the prerequisite went ready (details and logs in #338).

This PR distinguishes "waiting on a prerequisite" from real errors:

- `internal/errors`: new `WaitingError` sentinel (same shape as the existing non-retryable sentinel).
- BucketClaim/BucketAccess reconcilers wrap their prerequisite waitlists in `WaitingError` and map it in `Reconcile` to `reconcile.Result{RequeueAfter: 30s}` instead of an error — a steady poll that resets the rate limiter, keeps logs quiet (no `Reconciler error` spam for expected waits), and bounds the worst-case latency to 30s.
- Genuine errors (e.g. class not found) keep the error-backoff path unchanged.
- Tests updated: wait paths now assert `NoError` + `RequeueAfter: 30s`; error paths unchanged.

This is complementary to #254 (Bucket watchers): watchers would make reconciles event-driven; this bounds the damage of the current wait-loop design with a minimal change until then.

**Which issue(s) this PR fixes**:

Fixes #338

**Special notes for your reviewer**:

Observed in the wild (full-platform e2e): BucketAccesses stuck `readyToUse: false` 25+ minutes past Bucket-Ready; a controller restart (rate-limiter reset) resolved them in ~20s. Reproduction steps and log excerpts with the backoff doubling are in #338.

AI assistance disclosure: this change was developed with AI assistance (Claude Code). I have personally reviewed every line; the patched controller was validated end-to-end on the live cluster where the original stall reproduced (accesses now reconcile within the 30s poll window), and the unit test suite was extended for the new paths.

**Does this PR introduce a user-facing change?**:

```release-note
Prerequisite waits in the BucketClaim and BucketAccess reconcilers now requeue on a steady 30s interval instead of exponential error backoff, so objects reconcile promptly once their prerequisites become ready (previously up to ~17 minutes).
```
