### PR TITLE
fix: set correct api-approved annotation for CRDs

### DIFF
--- a/client/apis/objectstorage/v1alpha2/bucket_types.go
+++ b/client/apis/objectstorage/v1alpha2/bucket_types.go
@@ -183,7 +183,7 @@ type BucketStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental v1alpha2 changes"
+// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental-only"
 
 // Bucket is the Schema for the buckets API
 type Bucket struct {

--- a/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
+++ b/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
@@ -238,7 +238,7 @@ type AccessedBucket struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental v1alpha2 changes"
+// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental-only"
 
 // BucketAccess is the Schema for the bucketaccesses API
 type BucketAccess struct {

--- a/client/apis/objectstorage/v1alpha2/bucketaccessclass_types.go
+++ b/client/apis/objectstorage/v1alpha2/bucketaccessclass_types.go
@@ -90,7 +90,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental v1alpha2 changes"
+// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental-only"
 
 // BucketAccessClass is the Schema for the bucketaccessclasses API
 type BucketAccessClass struct {

--- a/client/apis/objectstorage/v1alpha2/bucketclaim_types.go
+++ b/client/apis/objectstorage/v1alpha2/bucketclaim_types.go
@@ -103,7 +103,7 @@ type BucketClaimStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental v1alpha2 changes"
+// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental-only"
 
 // BucketClaim is the Schema for the bucketclaims API
 type BucketClaim struct {

--- a/client/apis/objectstorage/v1alpha2/bucketclass_types.go
+++ b/client/apis/objectstorage/v1alpha2/bucketclass_types.go
@@ -52,7 +52,7 @@ type BucketClassSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental v1alpha2 changes"
+// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=unapproved, experimental-only"
 
 // BucketClass defines a named "class" of object storage buckets.
 // Different classes might map to different object storage protocols, quality-of-service levels,

--- a/client/config/crd/objectstorage.k8s.io_bucketaccessclasses.yaml
+++ b/client/config/crd/objectstorage.k8s.io_bucketaccessclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved, experimental v1alpha2 changes
+    api-approved.kubernetes.io: unapproved, experimental-only
     controller-gen.kubebuilder.io/version: v0.20.1
   name: bucketaccessclasses.objectstorage.k8s.io
 spec:

--- a/client/config/crd/objectstorage.k8s.io_bucketaccesses.yaml
+++ b/client/config/crd/objectstorage.k8s.io_bucketaccesses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved, experimental v1alpha2 changes
+    api-approved.kubernetes.io: unapproved, experimental-only
     controller-gen.kubebuilder.io/version: v0.20.1
   name: bucketaccesses.objectstorage.k8s.io
 spec:

--- a/client/config/crd/objectstorage.k8s.io_bucketclaims.yaml
+++ b/client/config/crd/objectstorage.k8s.io_bucketclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved, experimental v1alpha2 changes
+    api-approved.kubernetes.io: unapproved, experimental-only
     controller-gen.kubebuilder.io/version: v0.20.1
   name: bucketclaims.objectstorage.k8s.io
 spec:

--- a/client/config/crd/objectstorage.k8s.io_bucketclasses.yaml
+++ b/client/config/crd/objectstorage.k8s.io_bucketclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved, experimental v1alpha2 changes
+    api-approved.kubernetes.io: unapproved, experimental-only
     controller-gen.kubebuilder.io/version: v0.20.1
   name: bucketclasses.objectstorage.k8s.io
 spec:

--- a/client/config/crd/objectstorage.k8s.io_buckets.yaml
+++ b/client/config/crd/objectstorage.k8s.io_buckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.kubernetes.io: unapproved, experimental v1alpha2 changes
+    api-approved.kubernetes.io: unapproved, experimental-only
     controller-gen.kubebuilder.io/version: v0.20.1
   name: buckets.objectstorage.k8s.io
 spec:


### PR DESCRIPTION
Fixes #74

This updates the `api-approved.kubernetes.io` annotation value from `unapproved, experimental v1alpha2 changes` to `unapproved, experimental-only` as required by the Kubernetes API server for unapproved APIs.