### PR TITLE
Rename DriverGetExistingBucket RPC to DriverGetBucket

### DIFF
--- a/internal/test/rpc.go
+++ b/internal/test/rpc.go
@@ -109,7 +109,7 @@ type FakeProvisionerServer struct {
 	cosiproto.UnimplementedProvisionerServer
 
 	CreateBucketFunc       func(context.Context, *cosiproto.DriverCreateBucketRequest) (*cosiproto.DriverCreateBucketResponse, error)
-	GetExistingBucketFunc  func(context.Context, *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error)
+	GetBucketFunc          func(context.Context, *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error)
 	GrantBucketAccessFunc  func(context.Context, *cosiproto.DriverGrantBucketAccessRequest) (*cosiproto.DriverGrantBucketAccessResponse, error)
 	RevokeBucketAccessFunc func(context.Context, *cosiproto.DriverRevokeBucketAccessRequest) (*cosiproto.DriverRevokeBucketAccessResponse, error)
 }
@@ -124,14 +124,14 @@ func (s *FakeProvisionerServer) DriverCreateBucket(
 	panic("DriverCreateBucketFunc not implemented in FakeProvisionerServer")
 }
 
-func (s *FakeProvisionerServer) DriverGetExistingBucket(
-	ctx context.Context, req *cosiproto.DriverGetExistingBucketRequest,
-) (*cosiproto.DriverGetExistingBucketResponse, error) {
-	if s.GetExistingBucketFunc != nil {
-		return s.GetExistingBucketFunc(ctx, req)
+func (s *FakeProvisionerServer) DriverGetBucket(
+	ctx context.Context, req *cosiproto.DriverGetBucketRequest,
+) (*cosiproto.DriverGetBucketResponse, error) {
+	if s.GetBucketFunc != nil {
+		return s.GetBucketFunc(ctx, req)
 	}
 	// unit tests must set an expectation if they expect the call to be made
-	panic("DriverGetExistingBucketFunc not implemented in FakeProvisionerServer")
+	panic("DriverGetBucketFunc not implemented in FakeProvisionerServer")
 }
 
 func (s *FakeProvisionerServer) DriverGrantBucketAccess(

--- a/proto/cosi.pb.go
+++ b/proto/cosi.pb.go
@@ -1156,14 +1156,14 @@ func (x *DriverCreateBucketResponse) GetProtocols() *ObjectProtocolAndBucketInfo
 	return nil
 }
 
-type DriverGetExistingBucketRequest struct {
+type DriverGetBucketRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// REQUIRED. The unique identifier for the existing backend bucket known to the Provisioner.
 	// Provisioner MUST be able to correlate `bucket_id` to the backend bucket.
 	// It is RECOMMENDED to use the backend storage system's bucket ID.
 	// To prevent abuse, this must be at most 2048 characters long, consisting of alphanumeric
 	// characters ([a-z0-9A-Z]), dashes (-), and dots (.).
-	ExistingBucketId string `protobuf:"bytes,1,opt,name=existing_bucket_id,json=existingBucketId,proto3" json:"existing_bucket_id,omitempty"`
+	BucketId string `protobuf:"bytes,1,opt,name=bucket_id,json=bucketId,proto3" json:"bucket_id,omitempty"`
 	// OPTIONAL. A list of all object storage protocols the provisioned bucket MUST support.
 	// If none are given, the provisioner MAY provision with a set of default protocol(s) or return
 	// `InvalidArgument` with a message indicating that it requires this input.
@@ -1176,20 +1176,20 @@ type DriverGetExistingBucketRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DriverGetExistingBucketRequest) Reset() {
-	*x = DriverGetExistingBucketRequest{}
+func (x *DriverGetBucketRequest) Reset() {
+	*x = DriverGetBucketRequest{}
 	mi := &file_cosi_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DriverGetExistingBucketRequest) String() string {
+func (x *DriverGetBucketRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DriverGetExistingBucketRequest) ProtoMessage() {}
+func (*DriverGetBucketRequest) ProtoMessage() {}
 
-func (x *DriverGetExistingBucketRequest) ProtoReflect() protoreflect.Message {
+func (x *DriverGetBucketRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_cosi_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1201,33 +1201,33 @@ func (x *DriverGetExistingBucketRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DriverGetExistingBucketRequest.ProtoReflect.Descriptor instead.
-func (*DriverGetExistingBucketRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use DriverGetBucketRequest.ProtoReflect.Descriptor instead.
+func (*DriverGetBucketRequest) Descriptor() ([]byte, []int) {
 	return file_cosi_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *DriverGetExistingBucketRequest) GetExistingBucketId() string {
+func (x *DriverGetBucketRequest) GetBucketId() string {
 	if x != nil {
-		return x.ExistingBucketId
+		return x.BucketId
 	}
 	return ""
 }
 
-func (x *DriverGetExistingBucketRequest) GetProtocols() []*ObjectProtocol {
+func (x *DriverGetBucketRequest) GetProtocols() []*ObjectProtocol {
 	if x != nil {
 		return x.Protocols
 	}
 	return nil
 }
 
-func (x *DriverGetExistingBucketRequest) GetParameters() map[string]string {
+func (x *DriverGetBucketRequest) GetParameters() map[string]string {
 	if x != nil {
 		return x.Parameters
 	}
 	return nil
 }
 
-type DriverGetExistingBucketResponse struct {
+type DriverGetBucketResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// REQUIRED. The unique identifier for the backend bucket known to the Provisioner.
 	// This value WILL be used by COSI to make subsequent calls related to the bucket, so the
@@ -1257,20 +1257,20 @@ type DriverGetExistingBucketResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DriverGetExistingBucketResponse) Reset() {
-	*x = DriverGetExistingBucketResponse{}
+func (x *DriverGetBucketResponse) Reset() {
+	*x = DriverGetBucketResponse{}
 	mi := &file_cosi_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DriverGetExistingBucketResponse) String() string {
+func (x *DriverGetBucketResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DriverGetExistingBucketResponse) ProtoMessage() {}
+func (*DriverGetBucketResponse) ProtoMessage() {}
 
-func (x *DriverGetExistingBucketResponse) ProtoReflect() protoreflect.Message {
+func (x *DriverGetBucketResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_cosi_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1282,19 +1282,19 @@ func (x *DriverGetExistingBucketResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DriverGetExistingBucketResponse.ProtoReflect.Descriptor instead.
-func (*DriverGetExistingBucketResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use DriverGetBucketResponse.ProtoReflect.Descriptor instead.
+func (*DriverGetBucketResponse) Descriptor() ([]byte, []int) {
 	return file_cosi_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *DriverGetExistingBucketResponse) GetBucketId() string {
+func (x *DriverGetBucketResponse) GetBucketId() string {
 	if x != nil {
 		return x.BucketId
 	}
 	return ""
 }
 
-func (x *DriverGetExistingBucketResponse) GetProtocols() *ObjectProtocolAndBucketInfo {
+func (x *DriverGetBucketResponse) GetProtocols() *ObjectProtocolAndBucketInfo {
 	if x != nil {
 		return x.Protocols
 	}
@@ -2069,17 +2069,17 @@ const file_cosi_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8f\x01\n" +
 	"\x1aDriverCreateBucketResponse\x12\x1b\n" +
 	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\x12T\n" +
-	"\tprotocols\x18\x02 \x01(\v26.sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfoR\tprotocols\"\xc1\x02\n" +
-	"\x1eDriverGetExistingBucketRequest\x12,\n" +
-	"\x12existing_bucket_id\x18\x01 \x01(\tR\x10existingBucketId\x12G\n" +
-	"\tprotocols\x18\x02 \x03(\v2).sigs.k8s.io.cosi.v1alpha2.ObjectProtocolR\tprotocols\x12i\n" +
+	"\tprotocols\x18\x02 \x01(\v26.sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfoR\tprotocols\"\xa0\x02\n" +
+	"\x16DriverGetBucketRequest\x12\x1b\n" +
+	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\x12G\n" +
+	"\tprotocols\x18\x02 \x03(\v2).sigs.k8s.io.cosi.v1alpha2.ObjectProtocolR\tprotocols\x12a\n" +
 	"\n" +
-	"parameters\x18\x04 \x03(\v2I.sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.ParametersEntryR\n" +
+	"parameters\x18\x04 \x03(\v2A.sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.ParametersEntryR\n" +
 	"parameters\x1a=\n" +
 	"\x0fParametersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x94\x01\n" +
-	"\x1fDriverGetExistingBucketResponse\x12\x1b\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8c\x01\n" +
+	"\x17DriverGetBucketResponse\x12\x1b\n" +
 	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\x12T\n" +
 	"\tprotocols\x18\x02 \x01(\v26.sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfoR\tprotocols\"\xdd\x01\n" +
 	"\x19DriverDeleteBucketRequest\x12\x1b\n" +
@@ -2134,10 +2134,10 @@ const file_cosi_proto_rawDesc = "" +
 	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\"\"\n" +
 	" DriverRevokeBucketAccessResponse2\x80\x01\n" +
 	"\bIdentity\x12t\n" +
-	"\rDriverGetInfo\x12/.sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest\x1a0.sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse\"\x002\xd7\x05\n" +
+	"\rDriverGetInfo\x12/.sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest\x1a0.sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse\"\x002\xbe\x05\n" +
 	"\vProvisioner\x12\x83\x01\n" +
-	"\x12DriverCreateBucket\x124.sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest\x1a5.sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse\"\x00\x12\x92\x01\n" +
-	"\x17DriverGetExistingBucket\x129.sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest\x1a:.sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketResponse\"\x00\x12\x83\x01\n" +
+	"\x12DriverCreateBucket\x124.sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest\x1a5.sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse\"\x00\x12z\n" +
+	"\x0fDriverGetBucket\x121.sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest\x1a2.sigs.k8s.io.cosi.v1alpha2.DriverGetBucketResponse\"\x00\x12\x83\x01\n" +
 	"\x12DriverDeleteBucket\x124.sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest\x1a5.sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketResponse\"\x00\x12\x90\x01\n" +
 	"\x17DriverGrantBucketAccess\x129.sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest\x1a:.sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse\x12\x93\x01\n" +
 	"\x18DriverRevokeBucketAccess\x12:.sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest\x1a;.sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessResponse:<\n" +
@@ -2167,38 +2167,38 @@ func file_cosi_proto_rawDescGZIP() []byte {
 var file_cosi_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_cosi_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_cosi_proto_goTypes = []any{
-	(ObjectProtocol_Type)(0),                              // 0: sigs.k8s.io.cosi.v1alpha2.ObjectProtocol.Type
-	(S3AddressingStyle_Style)(0),                          // 1: sigs.k8s.io.cosi.v1alpha2.S3AddressingStyle.Style
-	(AuthenticationType_Type)(0),                          // 2: sigs.k8s.io.cosi.v1alpha2.AuthenticationType.Type
-	(AccessMode_Mode)(0),                                  // 3: sigs.k8s.io.cosi.v1alpha2.AccessMode.Mode
-	(*DriverGetInfoRequest)(nil),                          // 4: sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest
-	(*DriverGetInfoResponse)(nil),                         // 5: sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse
-	(*ObjectProtocol)(nil),                                // 6: sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
-	(*ObjectProtocolAndBucketInfo)(nil),                   // 7: sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
-	(*CredentialInfo)(nil),                                // 8: sigs.k8s.io.cosi.v1alpha2.CredentialInfo
-	(*S3BucketInfo)(nil),                                  // 9: sigs.k8s.io.cosi.v1alpha2.S3BucketInfo
-	(*S3CredentialInfo)(nil),                              // 10: sigs.k8s.io.cosi.v1alpha2.S3CredentialInfo
-	(*S3AddressingStyle)(nil),                             // 11: sigs.k8s.io.cosi.v1alpha2.S3AddressingStyle
-	(*AzureBucketInfo)(nil),                               // 12: sigs.k8s.io.cosi.v1alpha2.AzureBucketInfo
-	(*AzureCredentialInfo)(nil),                           // 13: sigs.k8s.io.cosi.v1alpha2.AzureCredentialInfo
-	(*GcsBucketInfo)(nil),                                 // 14: sigs.k8s.io.cosi.v1alpha2.GcsBucketInfo
-	(*GcsCredentialInfo)(nil),                             // 15: sigs.k8s.io.cosi.v1alpha2.GcsCredentialInfo
-	(*AuthenticationType)(nil),                            // 16: sigs.k8s.io.cosi.v1alpha2.AuthenticationType
-	(*AccessMode)(nil),                                    // 17: sigs.k8s.io.cosi.v1alpha2.AccessMode
-	(*DriverCreateBucketRequest)(nil),                     // 18: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest
-	(*DriverCreateBucketResponse)(nil),                    // 19: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse
-	(*DriverGetExistingBucketRequest)(nil),                // 20: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest
-	(*DriverGetExistingBucketResponse)(nil),               // 21: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketResponse
-	(*DriverDeleteBucketRequest)(nil),                     // 22: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest
-	(*DriverDeleteBucketResponse)(nil),                    // 23: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketResponse
-	(*DriverGrantBucketAccessRequest)(nil),                // 24: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest
-	(*DriverGrantBucketAccessResponse)(nil),               // 25: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse
-	(*DriverRevokeBucketAccessRequest)(nil),               // 26: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest
-	(*DriverRevokeBucketAccessResponse)(nil),              // 27: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessResponse
-	nil,                                                   // 28: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.ParametersEntry
-	nil,                                                   // 29: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.ParametersEntry
-	nil,                                                   // 30: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest.ParametersEntry
-	nil,                                                   // 31: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.ParametersEntry
+	(ObjectProtocol_Type)(0),                 // 0: sigs.k8s.io.cosi.v1alpha2.ObjectProtocol.Type
+	(S3AddressingStyle_Style)(0),             // 1: sigs.k8s.io.cosi.v1alpha2.S3AddressingStyle.Style
+	(AuthenticationType_Type)(0),             // 2: sigs.k8s.io.cosi.v1alpha2.AuthenticationType.Type
+	(AccessMode_Mode)(0),                     // 3: sigs.k8s.io.cosi.v1alpha2.AccessMode.Mode
+	(*DriverGetInfoRequest)(nil),             // 4: sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest
+	(*DriverGetInfoResponse)(nil),            // 5: sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse
+	(*ObjectProtocol)(nil),                   // 6: sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
+	(*ObjectProtocolAndBucketInfo)(nil),      // 7: sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
+	(*CredentialInfo)(nil),                   // 8: sigs.k8s.io.cosi.v1alpha2.CredentialInfo
+	(*S3BucketInfo)(nil),                     // 9: sigs.k8s.io.cosi.v1alpha2.S3BucketInfo
+	(*S3CredentialInfo)(nil),                 // 10: sigs.k8s.io.cosi.v1alpha2.S3CredentialInfo
+	(*S3AddressingStyle)(nil),                // 11: sigs.k8s.io.cosi.v1alpha2.S3AddressingStyle
+	(*AzureBucketInfo)(nil),                  // 12: sigs.k8s.io.cosi.v1alpha2.AzureBucketInfo
+	(*AzureCredentialInfo)(nil),              // 13: sigs.k8s.io.cosi.v1alpha2.AzureCredentialInfo
+	(*GcsBucketInfo)(nil),                    // 14: sigs.k8s.io.cosi.v1alpha2.GcsBucketInfo
+	(*GcsCredentialInfo)(nil),                // 15: sigs.k8s.io.cosi.v1alpha2.GcsCredentialInfo
+	(*AuthenticationType)(nil),               // 16: sigs.k8s.io.cosi.v1alpha2.AuthenticationType
+	(*AccessMode)(nil),                       // 17: sigs.k8s.io.cosi.v1alpha2.AccessMode
+	(*DriverCreateBucketRequest)(nil),        // 18: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest
+	(*DriverCreateBucketResponse)(nil),       // 19: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse
+	(*DriverGetBucketRequest)(nil),           // 20: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest
+	(*DriverGetBucketResponse)(nil),          // 21: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketResponse
+	(*DriverDeleteBucketRequest)(nil),        // 22: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest
+	(*DriverDeleteBucketResponse)(nil),       // 23: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketResponse
+	(*DriverGrantBucketAccessRequest)(nil),   // 24: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest
+	(*DriverGrantBucketAccessResponse)(nil),  // 25: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse
+	(*DriverRevokeBucketAccessRequest)(nil),  // 26: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest
+	(*DriverRevokeBucketAccessResponse)(nil), // 27: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessResponse
+	nil,                                      // 28: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.ParametersEntry
+	nil,                                      // 29: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.ParametersEntry
+	nil,                                      // 30: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest.ParametersEntry
+	nil,                                      // 31: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.ParametersEntry
 	(*DriverGrantBucketAccessRequest_AccessedBucket)(nil), // 32: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.AccessedBucket
 	(*DriverGrantBucketAccessResponse_BucketInfo)(nil),    // 33: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse.BucketInfo
 	nil, // 34: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest.ParametersEntry
@@ -2226,9 +2226,9 @@ var file_cosi_proto_depIdxs = []int32{
 	6,  // 12: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
 	28, // 13: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.parameters:type_name -> sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.ParametersEntry
 	7,  // 14: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
-	6,  // 15: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
-	29, // 16: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.parameters:type_name -> sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.ParametersEntry
-	7,  // 17: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketResponse.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
+	6,  // 15: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
+	29, // 16: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.parameters:type_name -> sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.ParametersEntry
+	7,  // 17: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketResponse.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
 	30, // 18: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest.parameters:type_name -> sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest.ParametersEntry
 	6,  // 19: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.protocol:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
 	16, // 20: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.authentication_type:type_name -> sigs.k8s.io.cosi.v1alpha2.AuthenticationType
@@ -2251,13 +2251,13 @@ var file_cosi_proto_depIdxs = []int32{
 	41, // 37: sigs.k8s.io.cosi.v1alpha2.alpha_service:extendee -> google.protobuf.ServiceOptions
 	4,  // 38: sigs.k8s.io.cosi.v1alpha2.Identity.DriverGetInfo:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest
 	18, // 39: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverCreateBucket:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest
-	20, // 40: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGetExistingBucket:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest
+	20, // 40: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGetBucket:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest
 	22, // 41: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverDeleteBucket:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest
 	24, // 42: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGrantBucketAccess:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest
 	26, // 43: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverRevokeBucketAccess:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest
 	5,  // 44: sigs.k8s.io.cosi.v1alpha2.Identity.DriverGetInfo:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse
 	19, // 45: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverCreateBucket:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse
-	21, // 46: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGetExistingBucket:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketResponse
+	21, // 46: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGetBucket:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetBucketResponse
 	23, // 47: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverDeleteBucket:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketResponse
 	25, // 48: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGrantBucketAccess:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse
 	27, // 49: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverRevokeBucketAccess:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessResponse

--- a/proto/cosi.pb.json.go
+++ b/proto/cosi.pb.json.go
@@ -264,7 +264,7 @@ func (msg *DriverCreateBucketResponse) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
-func (msg *DriverGetExistingBucketRequest) MarshalJSON() ([]byte, error) {
+func (msg *DriverGetBucketRequest) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseEnumNumbers:  false,
 		EmitUnpopulated: true,
@@ -273,14 +273,14 @@ func (msg *DriverGetExistingBucketRequest) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler
-func (msg *DriverGetExistingBucketRequest) UnmarshalJSON(b []byte) error {
+func (msg *DriverGetBucketRequest) UnmarshalJSON(b []byte) error {
 	return protojson.UnmarshalOptions{
 		DiscardUnknown: false,
 	}.Unmarshal(b, msg)
 }
 
 // MarshalJSON implements json.Marshaler
-func (msg *DriverGetExistingBucketResponse) MarshalJSON() ([]byte, error) {
+func (msg *DriverGetBucketResponse) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseEnumNumbers:  false,
 		EmitUnpopulated: true,
@@ -289,7 +289,7 @@ func (msg *DriverGetExistingBucketResponse) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler
-func (msg *DriverGetExistingBucketResponse) UnmarshalJSON(b []byte) error {
+func (msg *DriverGetBucketResponse) UnmarshalJSON(b []byte) error {
 	return protojson.UnmarshalOptions{
 		DiscardUnknown: false,
 	}.Unmarshal(b, msg)

--- a/proto/cosi.proto
+++ b/proto/cosi.proto
@@ -71,7 +71,7 @@ service Provisioner {
     // Important return codes:
     // - MUST return OK if a backend bucket with matching identity and parameters already exists.
     // - MUST return NOT_FOUND if a bucket with matching identity does not exist.
-    rpc DriverGetExistingBucket (DriverGetExistingBucketRequest) returns (DriverGetExistingBucketResponse) {}
+    rpc DriverGetBucket (DriverGetBucketRequest) returns (DriverGetBucketResponse) {}
 
     // Delete the bucket in the backend.
     //
@@ -322,13 +322,13 @@ message DriverCreateBucketResponse {
     ObjectProtocolAndBucketInfo protocols = 2;
 }
 
-message DriverGetExistingBucketRequest {
+message DriverGetBucketRequest {
     // REQUIRED. The unique identifier for the existing backend bucket known to the Provisioner.
     // Provisioner MUST be able to correlate `bucket_id` to the backend bucket.
     // It is RECOMMENDED to use the backend storage system's bucket ID.
     // To prevent abuse, this must be at most 2048 characters long, consisting of alphanumeric
     // characters ([a-z0-9A-Z]), dashes (-), and dots (.).
-    string existing_bucket_id = 1;
+    string bucket_id = 1;
 
     // OPTIONAL. A list of all object storage protocols the provisioned bucket MUST support.
     // If none are given, the provisioner MAY provision with a set of default protocol(s) or return
@@ -341,7 +341,7 @@ message DriverGetExistingBucketRequest {
     map<string, string> parameters = 4;
 }
 
-message DriverGetExistingBucketResponse {
+message DriverGetBucketResponse {
     // REQUIRED. The unique identifier for the backend bucket known to the Provisioner.
     // This value WILL be used by COSI to make subsequent calls related to the bucket, so the
     // Provisioner MUST be able to correlate `bucket_id` to the backend bucket.

--- a/proto/cosi_grpc.pb.go
+++ b/proto/cosi_grpc.pb.go
@@ -114,7 +114,7 @@ var Identity_ServiceDesc = grpc.ServiceDesc{
 
 const (
 	Provisioner_DriverCreateBucket_FullMethodName       = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverCreateBucket"
-	Provisioner_DriverGetExistingBucket_FullMethodName  = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverGetExistingBucket"
+	Provisioner_DriverGetBucket_FullMethodName          = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverGetBucket"
 	Provisioner_DriverDeleteBucket_FullMethodName       = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverDeleteBucket"
 	Provisioner_DriverGrantBucketAccess_FullMethodName  = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverGrantBucketAccess"
 	Provisioner_DriverRevokeBucketAccess_FullMethodName = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverRevokeBucketAccess"
@@ -135,7 +135,7 @@ type ProvisionerClient interface {
 	// Important return codes:
 	// - MUST return OK if a backend bucket with matching identity and parameters already exists.
 	// - MUST return NOT_FOUND if a bucket with matching identity does not exist.
-	DriverGetExistingBucket(ctx context.Context, in *DriverGetExistingBucketRequest, opts ...grpc.CallOption) (*DriverGetExistingBucketResponse, error)
+	DriverGetBucket(ctx context.Context, in *DriverGetBucketRequest, opts ...grpc.CallOption) (*DriverGetBucketResponse, error)
 	// Delete the bucket in the backend.
 	//
 	// Important return codes:
@@ -172,9 +172,9 @@ func (c *provisionerClient) DriverCreateBucket(ctx context.Context, in *DriverCr
 	return out, nil
 }
 
-func (c *provisionerClient) DriverGetExistingBucket(ctx context.Context, in *DriverGetExistingBucketRequest, opts ...grpc.CallOption) (*DriverGetExistingBucketResponse, error) {
-	out := new(DriverGetExistingBucketResponse)
-	err := c.cc.Invoke(ctx, Provisioner_DriverGetExistingBucket_FullMethodName, in, out, opts...)
+func (c *provisionerClient) DriverGetBucket(ctx context.Context, in *DriverGetBucketRequest, opts ...grpc.CallOption) (*DriverGetBucketResponse, error) {
+	out := new(DriverGetBucketResponse)
+	err := c.cc.Invoke(ctx, Provisioner_DriverGetBucket_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ type ProvisionerServer interface {
 	// Important return codes:
 	// - MUST return OK if a backend bucket with matching identity and parameters already exists.
 	// - MUST return NOT_FOUND if a bucket with matching identity does not exist.
-	DriverGetExistingBucket(context.Context, *DriverGetExistingBucketRequest) (*DriverGetExistingBucketResponse, error)
+	DriverGetBucket(context.Context, *DriverGetBucketRequest) (*DriverGetBucketResponse, error)
 	// Delete the bucket in the backend.
 	//
 	// Important return codes:
@@ -251,8 +251,8 @@ type UnimplementedProvisionerServer struct {
 func (UnimplementedProvisionerServer) DriverCreateBucket(context.Context, *DriverCreateBucketRequest) (*DriverCreateBucketResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DriverCreateBucket not implemented")
 }
-func (UnimplementedProvisionerServer) DriverGetExistingBucket(context.Context, *DriverGetExistingBucketRequest) (*DriverGetExistingBucketResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DriverGetExistingBucket not implemented")
+func (UnimplementedProvisionerServer) DriverGetBucket(context.Context, *DriverGetBucketRequest) (*DriverGetBucketResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DriverGetBucket not implemented")
 }
 func (UnimplementedProvisionerServer) DriverDeleteBucket(context.Context, *DriverDeleteBucketRequest) (*DriverDeleteBucketResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DriverDeleteBucket not implemented")
@@ -294,20 +294,20 @@ func _Provisioner_DriverCreateBucket_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Provisioner_DriverGetExistingBucket_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DriverGetExistingBucketRequest)
+func _Provisioner_DriverGetBucket_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DriverGetBucketRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProvisionerServer).DriverGetExistingBucket(ctx, in)
+		return srv.(ProvisionerServer).DriverGetBucket(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: Provisioner_DriverGetExistingBucket_FullMethodName,
+		FullMethod: Provisioner_DriverGetBucket_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProvisionerServer).DriverGetExistingBucket(ctx, req.(*DriverGetExistingBucketRequest))
+		return srv.(ProvisionerServer).DriverGetBucket(ctx, req.(*DriverGetBucketRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -378,8 +378,8 @@ var Provisioner_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _Provisioner_DriverCreateBucket_Handler,
 		},
 		{
-			MethodName: "DriverGetExistingBucket",
-			Handler:    _Provisioner_DriverGetExistingBucket_Handler,
+			MethodName: "DriverGetBucket",
+			Handler:    _Provisioner_DriverGetBucket_Handler,
 		},
 		{
 			MethodName: "DriverDeleteBucket",

--- a/proto/fake/cosi.pb.fake.go
+++ b/proto/fake/cosi.pb.fake.go
@@ -16,7 +16,7 @@ func (f *FakeIdentityClient) DriverGetInfo(ctx context.Context, in *proto.Driver
 
 type FakeProvisionerClient struct {
 	FakeDriverCreateBucket       func(ctx context.Context, in *proto.DriverCreateBucketRequest, opts ...grpc.CallOption) (*proto.DriverCreateBucketResponse, error)
-	FakeDriverGetExistingBucket  func(ctx context.Context, in *proto.DriverGetExistingBucketRequest, opts ...grpc.CallOption) (*proto.DriverGetExistingBucketResponse, error)
+	FakeDriverGetBucket          func(ctx context.Context, in *proto.DriverGetBucketRequest, opts ...grpc.CallOption) (*proto.DriverGetBucketResponse, error)
 	FakeDriverDeleteBucket       func(ctx context.Context, in *proto.DriverDeleteBucketRequest, opts ...grpc.CallOption) (*proto.DriverDeleteBucketResponse, error)
 	FakeDriverGrantBucketAccess  func(ctx context.Context, in *proto.DriverGrantBucketAccessRequest, opts ...grpc.CallOption) (*proto.DriverGrantBucketAccessResponse, error)
 	FakeDriverRevokeBucketAccess func(ctx context.Context, in *proto.DriverRevokeBucketAccessRequest, opts ...grpc.CallOption) (*proto.DriverRevokeBucketAccessResponse, error)
@@ -25,8 +25,8 @@ type FakeProvisionerClient struct {
 func (f *FakeProvisionerClient) DriverCreateBucket(ctx context.Context, in *proto.DriverCreateBucketRequest, opts ...grpc.CallOption) (*proto.DriverCreateBucketResponse, error) {
 	return f.FakeDriverCreateBucket(ctx, in, opts...)
 }
-func (f *FakeProvisionerClient) DriverGetExistingBucket(ctx context.Context, in *proto.DriverGetExistingBucketRequest, opts ...grpc.CallOption) (*proto.DriverGetExistingBucketResponse, error) {
-	return f.FakeDriverGetExistingBucket(ctx, in, opts...)
+func (f *FakeProvisionerClient) DriverGetBucket(ctx context.Context, in *proto.DriverGetBucketRequest, opts ...grpc.CallOption) (*proto.DriverGetBucketResponse, error) {
+	return f.FakeDriverGetBucket(ctx, in, opts...)
 }
 func (f *FakeProvisionerClient) DriverDeleteBucket(ctx context.Context, in *proto.DriverDeleteBucketRequest, opts ...grpc.CallOption) (*proto.DriverDeleteBucketResponse, error) {
 	return f.FakeDriverDeleteBucket(ctx, in, opts...)

--- a/proto/spec.md
+++ b/proto/spec.md
@@ -118,7 +118,7 @@ service Provisioner {
     // Important return codes:
     // - MUST return OK if a backend bucket with matching identity and parameters already exists.
     // - MUST return NOT_FOUND if a bucket with matching identity does not exist.
-    rpc DriverGetExistingBucket (DriverGetExistingBucketRequest) returns (DriverGetExistingBucketResponse) {}
+    rpc DriverGetBucket (DriverGetBucketRequest) returns (DriverGetBucketResponse) {}
 
     // Delete the bucket in the backend.
     //
@@ -493,7 +493,7 @@ message DriverCreateBucketResponse {
 }
 ```
 
-#### DriverGetExistingBucket
+#### DriverGetBucket
 
 A Plugin MUST implement this RPC call.
 
@@ -506,13 +506,13 @@ Important return codes:
 * `InvalidArgument` (not retryable) if any parameters are invalid for the backend.
 
 ```protobuf
-message DriverGetExistingBucketRequest {
+message DriverGetBucketRequest {
     // REQUIRED. The unique identifier for the existing backend bucket known to the Provisioner.
     // Provisioner MUST be able to correlate `bucket_id` to the backend bucket.
     // It is RECOMMENDED to use the backend storage system's bucket ID.
     // To prevent abuse, this must be at most 2048 characters long, consisting of alphanumeric
     // characters ([a-z0-9A-Z]), dashes (-), and dots (.).
-    string existing_bucket_id = 1;
+    string bucket_id = 1;
 
     // OPTIONAL. A list of all object storage protocols the provisioned bucket MUST support.
     // If none are given, the provisioner MAY provision with a set of default protocol(s) or return
@@ -525,7 +525,7 @@ message DriverGetExistingBucketRequest {
     map<string, string> parameters = 4;
 }
 
-message DriverGetExistingBucketResponse {
+message DriverGetBucketResponse {
     // REQUIRED. The unique identifier for the backend bucket known to the Provisioner.
     // This value WILL be used by COSI to make subsequent calls related to the bucket, so the
     // Provisioner MUST be able to correlate `bucket_id` to the backend bucket.

--- a/sidecar/pkg/reconciler/bucket.go
+++ b/sidecar/pkg/reconciler/bucket.go
@@ -323,21 +323,21 @@ func (r *BucketReconciler) staticProvision(
 			fmt.Errorf("bucketClaimRef namespace and name must be set for static provisioning: %#v", ref))
 	}
 
-	resp, err := r.DriverInfo.ProvisionerClient.DriverGetExistingBucket(ctx,
-		&cosiproto.DriverGetExistingBucketRequest{
-			ExistingBucketId: static.existingBucketID,
-			Protocols:        static.requiredProtos,
-			Parameters:       static.parameters,
+	resp, err := r.DriverInfo.ProvisionerClient.DriverGetBucket(ctx,
+		&cosiproto.DriverGetBucketRequest{
+			BucketId:   static.existingBucketID,
+			Protocols:  static.requiredProtos,
+			Parameters: static.parameters,
 		},
 	)
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
 			err = fmt.Errorf("waiting for backend bucket to exist: %w", err)
-			logger.Error(err, "DriverGetExistingBucket error")
+			logger.Error(err, "DriverGetBucket error")
 			return nil, err
 		}
 
-		logger.Error(err, "DriverGetExistingBucket error")
+		logger.Error(err, "DriverGetBucket error")
 		if rpcErrorIsRetryable(status.Code(err)) {
 			return nil, err
 		}

--- a/sidecar/pkg/reconciler/bucket_test.go
+++ b/sidecar/pkg/reconciler/bucket_test.go
@@ -456,7 +456,7 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("static provisioning, happy path", func(t *testing.T) {
-		getBucketReq := []*cosiproto.DriverGetExistingBucketRequest{}
+		getBucketReq := []*cosiproto.DriverGetBucketRequest{}
 		createBucketReq := []*cosiproto.DriverCreateBucketRequest{}
 		var requestError error
 		fakeServer := cositest.FakeProvisionerServer{
@@ -464,17 +464,17 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 				createBucketReq = append(createBucketReq, dcbr)
 				return nil, fmt.Errorf("DriverCreateBucket must not be called for static provisioning")
 			},
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				getBucketReq = append(getBucketReq, dgebr)
 				if requestError != nil {
 					return nil, requestError
 				}
-				ret := &cosiproto.DriverGetExistingBucketResponse{
-					BucketId: dgebr.ExistingBucketId,
+				ret := &cosiproto.DriverGetBucketResponse{
+					BucketId: dgebr.BucketId,
 					Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
 						S3: &cosiproto.S3BucketInfo{
 							Endpoint:        "s3.corp.net",
-							BucketId:        dgebr.ExistingBucketId,
+							BucketId:        dgebr.BucketId,
 							Region:          "us-east-1",
 							AddressingStyle: &cosiproto.S3AddressingStyle{Style: cosiproto.S3AddressingStyle_PATH},
 						},
@@ -518,7 +518,7 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 
 		require.Len(t, getBucketReq, 1)
 		req := getBucketReq[0]
-		assert.Equal(t, "static-bucket", req.ExistingBucketId)
+		assert.Equal(t, "static-bucket", req.BucketId)
 		assert.Equal(t, []*cosiproto.ObjectProtocol{{Type: cosiproto.ObjectProtocol_S3}}, req.Protocols)
 		assert.Equal(t, map[string]string{"maxSize": "10Gi"}, req.Parameters)
 		// "DriverCreateBucket" must not be called for static provisioning
@@ -544,7 +544,7 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, res)
 		require.Len(t, getBucketReq, 1)
-		assert.Equal(t, "static-bucket", getBucketReq[0].ExistingBucketId)
+		assert.Equal(t, "static-bucket", getBucketReq[0].BucketId)
 		require.Len(t, createBucketReq, 0)
 
 		secondBucket := &cosiapi.Bucket{}
@@ -598,21 +598,21 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("static provisioning, driver name mismatch", func(t *testing.T) {
-		getBucketReq := []*cosiproto.DriverGetExistingBucketRequest{}
+		getBucketReq := []*cosiproto.DriverGetBucketRequest{}
 		createBucketReq := []*cosiproto.DriverCreateBucketRequest{}
 		fakeServer := cositest.FakeProvisionerServer{
 			CreateBucketFunc: func(ctx context.Context, dcbr *cosiproto.DriverCreateBucketRequest) (*cosiproto.DriverCreateBucketResponse, error) {
 				createBucketReq = append(createBucketReq, dcbr)
 				return nil, fmt.Errorf("DriverCreateBucket must not be called for static provisioning")
 			},
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				getBucketReq = append(getBucketReq, dgebr)
-				return &cosiproto.DriverGetExistingBucketResponse{
-					BucketId: dgebr.ExistingBucketId,
+				return &cosiproto.DriverGetBucketResponse{
+					BucketId: dgebr.BucketId,
 					Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
 						S3: &cosiproto.S3BucketInfo{
 							Endpoint:        "s3.corp.net",
-							BucketId:        dgebr.ExistingBucketId,
+							BucketId:        dgebr.BucketId,
 							Region:          "us-east-1",
 							AddressingStyle: &cosiproto.S3AddressingStyle{Style: cosiproto.S3AddressingStyle_PATH},
 						},
@@ -662,16 +662,16 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("static provisioning, proto not supported", func(t *testing.T) {
-		getBucketReq := []*cosiproto.DriverGetExistingBucketRequest{}
+		getBucketReq := []*cosiproto.DriverGetBucketRequest{}
 		createBucketReq := []*cosiproto.DriverCreateBucketRequest{}
 		fakeServer := cositest.FakeProvisionerServer{
 			CreateBucketFunc: func(ctx context.Context, dcbr *cosiproto.DriverCreateBucketRequest) (*cosiproto.DriverCreateBucketResponse, error) {
 				createBucketReq = append(createBucketReq, dcbr)
 				return nil, fmt.Errorf("DriverCreateBucket must not be called for static provisioning")
 			},
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				getBucketReq = append(getBucketReq, dgebr)
-				return &cosiproto.DriverGetExistingBucketResponse{}, nil
+				return &cosiproto.DriverGetBucketResponse{}, nil
 			},
 		}
 
@@ -721,14 +721,14 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("static provisioning, backend bucket not found (error with retry)", func(t *testing.T) {
-		getBucketReq := []*cosiproto.DriverGetExistingBucketRequest{}
+		getBucketReq := []*cosiproto.DriverGetBucketRequest{}
 		createBucketReq := []*cosiproto.DriverCreateBucketRequest{}
 		fakeServer := cositest.FakeProvisionerServer{
 			CreateBucketFunc: func(ctx context.Context, dcbr *cosiproto.DriverCreateBucketRequest) (*cosiproto.DriverCreateBucketResponse, error) {
 				createBucketReq = append(createBucketReq, dcbr)
 				return nil, fmt.Errorf("DriverCreateBucket must not be called for static provisioning")
 			},
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				getBucketReq = append(getBucketReq, dgebr)
 				return nil, status.Error(codes.NotFound, "bucket does not exist in backend")
 			},
@@ -764,7 +764,7 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 		assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
 		assert.Empty(t, res)
 		require.Len(t, getBucketReq, 1)
-		assert.Equal(t, "static-bucket", getBucketReq[0].ExistingBucketId)
+		assert.Equal(t, "static-bucket", getBucketReq[0].BucketId)
 		require.Len(t, createBucketReq, 0)
 
 		bucket := &cosiapi.Bucket{}
@@ -780,17 +780,17 @@ func TestBucketReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("static provisioning, provisioned bucket supports wrong proto", func(t *testing.T) {
-		getBucketReq := []*cosiproto.DriverGetExistingBucketRequest{}
+		getBucketReq := []*cosiproto.DriverGetBucketRequest{}
 		createBucketReq := []*cosiproto.DriverCreateBucketRequest{}
 		fakeServer := cositest.FakeProvisionerServer{
 			CreateBucketFunc: func(ctx context.Context, dcbr *cosiproto.DriverCreateBucketRequest) (*cosiproto.DriverCreateBucketResponse, error) {
 				createBucketReq = append(createBucketReq, dcbr)
 				return nil, fmt.Errorf("DriverCreateBucket must not be called for static provisioning")
 			},
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				getBucketReq = append(getBucketReq, dgebr)
-				ret := &cosiproto.DriverGetExistingBucketResponse{
-					BucketId: dgebr.ExistingBucketId,
+				ret := &cosiproto.DriverGetBucketResponse{
+					BucketId: dgebr.BucketId,
 					Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
 						Azure: &cosiproto.AzureBucketInfo{}, // bucket.spec wants S3
 					},
@@ -1348,14 +1348,14 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 	t.Run("valid driver and bucket, successful provision", func(t *testing.T) {
 		requestParams := map[string]string{}
 		fakeServer := cositest.FakeProvisionerServer{
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				requestParams = dgebr.Parameters
-				ret := &cosiproto.DriverGetExistingBucketResponse{
-					BucketId: dgebr.ExistingBucketId,
+				ret := &cosiproto.DriverGetBucketResponse{
+					BucketId: dgebr.BucketId,
 					Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
 						S3: &cosiproto.S3BucketInfo{
 							Endpoint:        "s3.corp.net",
-							BucketId:        dgebr.ExistingBucketId,
+							BucketId:        dgebr.BucketId,
 							Region:          "us-east-1",
 							AddressingStyle: &cosiproto.S3AddressingStyle{Style: cosiproto.S3AddressingStyle_PATH},
 						},
@@ -1407,13 +1407,13 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 
 	t.Run("valid driver, claim ref malformed", func(t *testing.T) {
 		fakeServer := cositest.FakeProvisionerServer{
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
-				return &cosiproto.DriverGetExistingBucketResponse{
-					BucketId: dgebr.ExistingBucketId,
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
+				return &cosiproto.DriverGetBucketResponse{
+					BucketId: dgebr.BucketId,
 					Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
 						S3: &cosiproto.S3BucketInfo{
 							Endpoint:        "s3.corp.net",
-							BucketId:        dgebr.ExistingBucketId,
+							BucketId:        dgebr.BucketId,
 							Region:          "us-east-1",
 							AddressingStyle: &cosiproto.S3AddressingStyle{Style: cosiproto.S3AddressingStyle_PATH},
 						},
@@ -1466,7 +1466,7 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 
 	t.Run("valid driver, retryable provision error", func(t *testing.T) {
 		fakeServer := cositest.FakeProvisionerServer{
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				return nil, status.Error(codes.Unknown, "fake unknown err")
 			},
 		}
@@ -1504,7 +1504,7 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 
 	t.Run("valid driver, non-retryable provision error", func(t *testing.T) {
 		fakeServer := cositest.FakeProvisionerServer{
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				return nil, status.Error(codes.InvalidArgument, "fake invalid arg err")
 			},
 		}
@@ -1542,7 +1542,7 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 
 	t.Run("valid driver, bucket does not exist", func(t *testing.T) {
 		fakeServer := cositest.FakeProvisionerServer{
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
 				return nil, status.Error(codes.NotFound, "bucket does not exist")
 			},
 		}
@@ -1580,13 +1580,13 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 
 	t.Run("valid driver, bucket ID missing in response", func(t *testing.T) {
 		fakeServer := cositest.FakeProvisionerServer{
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
-				return &cosiproto.DriverGetExistingBucketResponse{
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
+				return &cosiproto.DriverGetBucketResponse{
 					BucketId: "", // MISSING
 					Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
 						S3: &cosiproto.S3BucketInfo{
 							Endpoint:        "s3.corp.net",
-							BucketId:        dgebr.ExistingBucketId,
+							BucketId:        dgebr.BucketId,
 							Region:          "us-east-1",
 							AddressingStyle: &cosiproto.S3AddressingStyle{Style: cosiproto.S3AddressingStyle_PATH},
 						},
@@ -1628,9 +1628,9 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 
 	t.Run("valid driver, proto response nil", func(t *testing.T) {
 		fakeServer := cositest.FakeProvisionerServer{
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
-				return &cosiproto.DriverGetExistingBucketResponse{
-					BucketId:  dgebr.ExistingBucketId,
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
+				return &cosiproto.DriverGetBucketResponse{
+					BucketId:  dgebr.BucketId,
 					Protocols: nil,
 				}, nil
 			},
@@ -1669,9 +1669,9 @@ func TestBucketReconciler_staticProvision(t *testing.T) {
 
 	t.Run("valid driver, empty S3 proto response", func(t *testing.T) {
 		fakeServer := cositest.FakeProvisionerServer{
-			GetExistingBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetExistingBucketRequest) (*cosiproto.DriverGetExistingBucketResponse, error) {
-				return &cosiproto.DriverGetExistingBucketResponse{
-					BucketId: dgebr.ExistingBucketId,
+			GetBucketFunc: func(ctx context.Context, dgebr *cosiproto.DriverGetBucketRequest) (*cosiproto.DriverGetBucketResponse, error) {
+				return &cosiproto.DriverGetBucketResponse{
+					BucketId: dgebr.BucketId,
 					Protocols: &cosiproto.ObjectProtocolAndBucketInfo{
 						S3: &cosiproto.S3BucketInfo{},
 					},

--- a/vendor/sigs.k8s.io/container-object-storage-interface/proto/cosi.pb.go
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/proto/cosi.pb.go
@@ -1156,14 +1156,14 @@ func (x *DriverCreateBucketResponse) GetProtocols() *ObjectProtocolAndBucketInfo
 	return nil
 }
 
-type DriverGetExistingBucketRequest struct {
+type DriverGetBucketRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// REQUIRED. The unique identifier for the existing backend bucket known to the Provisioner.
 	// Provisioner MUST be able to correlate `bucket_id` to the backend bucket.
 	// It is RECOMMENDED to use the backend storage system's bucket ID.
 	// To prevent abuse, this must be at most 2048 characters long, consisting of alphanumeric
 	// characters ([a-z0-9A-Z]), dashes (-), and dots (.).
-	ExistingBucketId string `protobuf:"bytes,1,opt,name=existing_bucket_id,json=existingBucketId,proto3" json:"existing_bucket_id,omitempty"`
+	BucketId string `protobuf:"bytes,1,opt,name=bucket_id,json=bucketId,proto3" json:"bucket_id,omitempty"`
 	// OPTIONAL. A list of all object storage protocols the provisioned bucket MUST support.
 	// If none are given, the provisioner MAY provision with a set of default protocol(s) or return
 	// `InvalidArgument` with a message indicating that it requires this input.
@@ -1176,20 +1176,20 @@ type DriverGetExistingBucketRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DriverGetExistingBucketRequest) Reset() {
-	*x = DriverGetExistingBucketRequest{}
+func (x *DriverGetBucketRequest) Reset() {
+	*x = DriverGetBucketRequest{}
 	mi := &file_cosi_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DriverGetExistingBucketRequest) String() string {
+func (x *DriverGetBucketRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DriverGetExistingBucketRequest) ProtoMessage() {}
+func (*DriverGetBucketRequest) ProtoMessage() {}
 
-func (x *DriverGetExistingBucketRequest) ProtoReflect() protoreflect.Message {
+func (x *DriverGetBucketRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_cosi_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1201,33 +1201,33 @@ func (x *DriverGetExistingBucketRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DriverGetExistingBucketRequest.ProtoReflect.Descriptor instead.
-func (*DriverGetExistingBucketRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use DriverGetBucketRequest.ProtoReflect.Descriptor instead.
+func (*DriverGetBucketRequest) Descriptor() ([]byte, []int) {
 	return file_cosi_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *DriverGetExistingBucketRequest) GetExistingBucketId() string {
+func (x *DriverGetBucketRequest) GetBucketId() string {
 	if x != nil {
-		return x.ExistingBucketId
+		return x.BucketId
 	}
 	return ""
 }
 
-func (x *DriverGetExistingBucketRequest) GetProtocols() []*ObjectProtocol {
+func (x *DriverGetBucketRequest) GetProtocols() []*ObjectProtocol {
 	if x != nil {
 		return x.Protocols
 	}
 	return nil
 }
 
-func (x *DriverGetExistingBucketRequest) GetParameters() map[string]string {
+func (x *DriverGetBucketRequest) GetParameters() map[string]string {
 	if x != nil {
 		return x.Parameters
 	}
 	return nil
 }
 
-type DriverGetExistingBucketResponse struct {
+type DriverGetBucketResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// REQUIRED. The unique identifier for the backend bucket known to the Provisioner.
 	// This value WILL be used by COSI to make subsequent calls related to the bucket, so the
@@ -1257,20 +1257,20 @@ type DriverGetExistingBucketResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DriverGetExistingBucketResponse) Reset() {
-	*x = DriverGetExistingBucketResponse{}
+func (x *DriverGetBucketResponse) Reset() {
+	*x = DriverGetBucketResponse{}
 	mi := &file_cosi_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DriverGetExistingBucketResponse) String() string {
+func (x *DriverGetBucketResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DriverGetExistingBucketResponse) ProtoMessage() {}
+func (*DriverGetBucketResponse) ProtoMessage() {}
 
-func (x *DriverGetExistingBucketResponse) ProtoReflect() protoreflect.Message {
+func (x *DriverGetBucketResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_cosi_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1282,19 +1282,19 @@ func (x *DriverGetExistingBucketResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DriverGetExistingBucketResponse.ProtoReflect.Descriptor instead.
-func (*DriverGetExistingBucketResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use DriverGetBucketResponse.ProtoReflect.Descriptor instead.
+func (*DriverGetBucketResponse) Descriptor() ([]byte, []int) {
 	return file_cosi_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *DriverGetExistingBucketResponse) GetBucketId() string {
+func (x *DriverGetBucketResponse) GetBucketId() string {
 	if x != nil {
 		return x.BucketId
 	}
 	return ""
 }
 
-func (x *DriverGetExistingBucketResponse) GetProtocols() *ObjectProtocolAndBucketInfo {
+func (x *DriverGetBucketResponse) GetProtocols() *ObjectProtocolAndBucketInfo {
 	if x != nil {
 		return x.Protocols
 	}
@@ -2069,17 +2069,17 @@ const file_cosi_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8f\x01\n" +
 	"\x1aDriverCreateBucketResponse\x12\x1b\n" +
 	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\x12T\n" +
-	"\tprotocols\x18\x02 \x01(\v26.sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfoR\tprotocols\"\xc1\x02\n" +
-	"\x1eDriverGetExistingBucketRequest\x12,\n" +
-	"\x12existing_bucket_id\x18\x01 \x01(\tR\x10existingBucketId\x12G\n" +
-	"\tprotocols\x18\x02 \x03(\v2).sigs.k8s.io.cosi.v1alpha2.ObjectProtocolR\tprotocols\x12i\n" +
+	"\tprotocols\x18\x02 \x01(\v26.sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfoR\tprotocols\"\xa0\x02\n" +
+	"\x16DriverGetBucketRequest\x12\x1b\n" +
+	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\x12G\n" +
+	"\tprotocols\x18\x02 \x03(\v2).sigs.k8s.io.cosi.v1alpha2.ObjectProtocolR\tprotocols\x12a\n" +
 	"\n" +
-	"parameters\x18\x04 \x03(\v2I.sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.ParametersEntryR\n" +
+	"parameters\x18\x04 \x03(\v2A.sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.ParametersEntryR\n" +
 	"parameters\x1a=\n" +
 	"\x0fParametersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x94\x01\n" +
-	"\x1fDriverGetExistingBucketResponse\x12\x1b\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8c\x01\n" +
+	"\x17DriverGetBucketResponse\x12\x1b\n" +
 	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\x12T\n" +
 	"\tprotocols\x18\x02 \x01(\v26.sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfoR\tprotocols\"\xdd\x01\n" +
 	"\x19DriverDeleteBucketRequest\x12\x1b\n" +
@@ -2134,10 +2134,10 @@ const file_cosi_proto_rawDesc = "" +
 	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\"\"\n" +
 	" DriverRevokeBucketAccessResponse2\x80\x01\n" +
 	"\bIdentity\x12t\n" +
-	"\rDriverGetInfo\x12/.sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest\x1a0.sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse\"\x002\xd7\x05\n" +
+	"\rDriverGetInfo\x12/.sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest\x1a0.sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse\"\x002\xbe\x05\n" +
 	"\vProvisioner\x12\x83\x01\n" +
-	"\x12DriverCreateBucket\x124.sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest\x1a5.sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse\"\x00\x12\x92\x01\n" +
-	"\x17DriverGetExistingBucket\x129.sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest\x1a:.sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketResponse\"\x00\x12\x83\x01\n" +
+	"\x12DriverCreateBucket\x124.sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest\x1a5.sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse\"\x00\x12z\n" +
+	"\x0fDriverGetBucket\x121.sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest\x1a2.sigs.k8s.io.cosi.v1alpha2.DriverGetBucketResponse\"\x00\x12\x83\x01\n" +
 	"\x12DriverDeleteBucket\x124.sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest\x1a5.sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketResponse\"\x00\x12\x90\x01\n" +
 	"\x17DriverGrantBucketAccess\x129.sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest\x1a:.sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse\x12\x93\x01\n" +
 	"\x18DriverRevokeBucketAccess\x12:.sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest\x1a;.sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessResponse:<\n" +
@@ -2167,38 +2167,38 @@ func file_cosi_proto_rawDescGZIP() []byte {
 var file_cosi_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_cosi_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_cosi_proto_goTypes = []any{
-	(ObjectProtocol_Type)(0),                              // 0: sigs.k8s.io.cosi.v1alpha2.ObjectProtocol.Type
-	(S3AddressingStyle_Style)(0),                          // 1: sigs.k8s.io.cosi.v1alpha2.S3AddressingStyle.Style
-	(AuthenticationType_Type)(0),                          // 2: sigs.k8s.io.cosi.v1alpha2.AuthenticationType.Type
-	(AccessMode_Mode)(0),                                  // 3: sigs.k8s.io.cosi.v1alpha2.AccessMode.Mode
-	(*DriverGetInfoRequest)(nil),                          // 4: sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest
-	(*DriverGetInfoResponse)(nil),                         // 5: sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse
-	(*ObjectProtocol)(nil),                                // 6: sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
-	(*ObjectProtocolAndBucketInfo)(nil),                   // 7: sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
-	(*CredentialInfo)(nil),                                // 8: sigs.k8s.io.cosi.v1alpha2.CredentialInfo
-	(*S3BucketInfo)(nil),                                  // 9: sigs.k8s.io.cosi.v1alpha2.S3BucketInfo
-	(*S3CredentialInfo)(nil),                              // 10: sigs.k8s.io.cosi.v1alpha2.S3CredentialInfo
-	(*S3AddressingStyle)(nil),                             // 11: sigs.k8s.io.cosi.v1alpha2.S3AddressingStyle
-	(*AzureBucketInfo)(nil),                               // 12: sigs.k8s.io.cosi.v1alpha2.AzureBucketInfo
-	(*AzureCredentialInfo)(nil),                           // 13: sigs.k8s.io.cosi.v1alpha2.AzureCredentialInfo
-	(*GcsBucketInfo)(nil),                                 // 14: sigs.k8s.io.cosi.v1alpha2.GcsBucketInfo
-	(*GcsCredentialInfo)(nil),                             // 15: sigs.k8s.io.cosi.v1alpha2.GcsCredentialInfo
-	(*AuthenticationType)(nil),                            // 16: sigs.k8s.io.cosi.v1alpha2.AuthenticationType
-	(*AccessMode)(nil),                                    // 17: sigs.k8s.io.cosi.v1alpha2.AccessMode
-	(*DriverCreateBucketRequest)(nil),                     // 18: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest
-	(*DriverCreateBucketResponse)(nil),                    // 19: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse
-	(*DriverGetExistingBucketRequest)(nil),                // 20: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest
-	(*DriverGetExistingBucketResponse)(nil),               // 21: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketResponse
-	(*DriverDeleteBucketRequest)(nil),                     // 22: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest
-	(*DriverDeleteBucketResponse)(nil),                    // 23: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketResponse
-	(*DriverGrantBucketAccessRequest)(nil),                // 24: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest
-	(*DriverGrantBucketAccessResponse)(nil),               // 25: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse
-	(*DriverRevokeBucketAccessRequest)(nil),               // 26: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest
-	(*DriverRevokeBucketAccessResponse)(nil),              // 27: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessResponse
-	nil,                                                   // 28: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.ParametersEntry
-	nil,                                                   // 29: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.ParametersEntry
-	nil,                                                   // 30: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest.ParametersEntry
-	nil,                                                   // 31: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.ParametersEntry
+	(ObjectProtocol_Type)(0),                 // 0: sigs.k8s.io.cosi.v1alpha2.ObjectProtocol.Type
+	(S3AddressingStyle_Style)(0),             // 1: sigs.k8s.io.cosi.v1alpha2.S3AddressingStyle.Style
+	(AuthenticationType_Type)(0),             // 2: sigs.k8s.io.cosi.v1alpha2.AuthenticationType.Type
+	(AccessMode_Mode)(0),                     // 3: sigs.k8s.io.cosi.v1alpha2.AccessMode.Mode
+	(*DriverGetInfoRequest)(nil),             // 4: sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest
+	(*DriverGetInfoResponse)(nil),            // 5: sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse
+	(*ObjectProtocol)(nil),                   // 6: sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
+	(*ObjectProtocolAndBucketInfo)(nil),      // 7: sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
+	(*CredentialInfo)(nil),                   // 8: sigs.k8s.io.cosi.v1alpha2.CredentialInfo
+	(*S3BucketInfo)(nil),                     // 9: sigs.k8s.io.cosi.v1alpha2.S3BucketInfo
+	(*S3CredentialInfo)(nil),                 // 10: sigs.k8s.io.cosi.v1alpha2.S3CredentialInfo
+	(*S3AddressingStyle)(nil),                // 11: sigs.k8s.io.cosi.v1alpha2.S3AddressingStyle
+	(*AzureBucketInfo)(nil),                  // 12: sigs.k8s.io.cosi.v1alpha2.AzureBucketInfo
+	(*AzureCredentialInfo)(nil),              // 13: sigs.k8s.io.cosi.v1alpha2.AzureCredentialInfo
+	(*GcsBucketInfo)(nil),                    // 14: sigs.k8s.io.cosi.v1alpha2.GcsBucketInfo
+	(*GcsCredentialInfo)(nil),                // 15: sigs.k8s.io.cosi.v1alpha2.GcsCredentialInfo
+	(*AuthenticationType)(nil),               // 16: sigs.k8s.io.cosi.v1alpha2.AuthenticationType
+	(*AccessMode)(nil),                       // 17: sigs.k8s.io.cosi.v1alpha2.AccessMode
+	(*DriverCreateBucketRequest)(nil),        // 18: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest
+	(*DriverCreateBucketResponse)(nil),       // 19: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse
+	(*DriverGetBucketRequest)(nil),           // 20: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest
+	(*DriverGetBucketResponse)(nil),          // 21: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketResponse
+	(*DriverDeleteBucketRequest)(nil),        // 22: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest
+	(*DriverDeleteBucketResponse)(nil),       // 23: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketResponse
+	(*DriverGrantBucketAccessRequest)(nil),   // 24: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest
+	(*DriverGrantBucketAccessResponse)(nil),  // 25: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse
+	(*DriverRevokeBucketAccessRequest)(nil),  // 26: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest
+	(*DriverRevokeBucketAccessResponse)(nil), // 27: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessResponse
+	nil,                                      // 28: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.ParametersEntry
+	nil,                                      // 29: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.ParametersEntry
+	nil,                                      // 30: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest.ParametersEntry
+	nil,                                      // 31: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.ParametersEntry
 	(*DriverGrantBucketAccessRequest_AccessedBucket)(nil), // 32: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.AccessedBucket
 	(*DriverGrantBucketAccessResponse_BucketInfo)(nil),    // 33: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse.BucketInfo
 	nil, // 34: sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest.ParametersEntry
@@ -2226,9 +2226,9 @@ var file_cosi_proto_depIdxs = []int32{
 	6,  // 12: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
 	28, // 13: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.parameters:type_name -> sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest.ParametersEntry
 	7,  // 14: sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
-	6,  // 15: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
-	29, // 16: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.parameters:type_name -> sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest.ParametersEntry
-	7,  // 17: sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketResponse.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
+	6,  // 15: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
+	29, // 16: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.parameters:type_name -> sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest.ParametersEntry
+	7,  // 17: sigs.k8s.io.cosi.v1alpha2.DriverGetBucketResponse.protocols:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocolAndBucketInfo
 	30, // 18: sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest.parameters:type_name -> sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest.ParametersEntry
 	6,  // 19: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.protocol:type_name -> sigs.k8s.io.cosi.v1alpha2.ObjectProtocol
 	16, // 20: sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest.authentication_type:type_name -> sigs.k8s.io.cosi.v1alpha2.AuthenticationType
@@ -2251,13 +2251,13 @@ var file_cosi_proto_depIdxs = []int32{
 	41, // 37: sigs.k8s.io.cosi.v1alpha2.alpha_service:extendee -> google.protobuf.ServiceOptions
 	4,  // 38: sigs.k8s.io.cosi.v1alpha2.Identity.DriverGetInfo:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetInfoRequest
 	18, // 39: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverCreateBucket:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketRequest
-	20, // 40: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGetExistingBucket:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketRequest
+	20, // 40: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGetBucket:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetBucketRequest
 	22, // 41: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverDeleteBucket:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketRequest
 	24, // 42: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGrantBucketAccess:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessRequest
 	26, // 43: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverRevokeBucketAccess:input_type -> sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessRequest
 	5,  // 44: sigs.k8s.io.cosi.v1alpha2.Identity.DriverGetInfo:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetInfoResponse
 	19, // 45: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverCreateBucket:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverCreateBucketResponse
-	21, // 46: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGetExistingBucket:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetExistingBucketResponse
+	21, // 46: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGetBucket:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverGetBucketResponse
 	23, // 47: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverDeleteBucket:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverDeleteBucketResponse
 	25, // 48: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverGrantBucketAccess:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverGrantBucketAccessResponse
 	27, // 49: sigs.k8s.io.cosi.v1alpha2.Provisioner.DriverRevokeBucketAccess:output_type -> sigs.k8s.io.cosi.v1alpha2.DriverRevokeBucketAccessResponse

--- a/vendor/sigs.k8s.io/container-object-storage-interface/proto/cosi.pb.json.go
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/proto/cosi.pb.json.go
@@ -264,7 +264,7 @@ func (msg *DriverCreateBucketResponse) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
-func (msg *DriverGetExistingBucketRequest) MarshalJSON() ([]byte, error) {
+func (msg *DriverGetBucketRequest) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseEnumNumbers:  false,
 		EmitUnpopulated: true,
@@ -273,14 +273,14 @@ func (msg *DriverGetExistingBucketRequest) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler
-func (msg *DriverGetExistingBucketRequest) UnmarshalJSON(b []byte) error {
+func (msg *DriverGetBucketRequest) UnmarshalJSON(b []byte) error {
 	return protojson.UnmarshalOptions{
 		DiscardUnknown: false,
 	}.Unmarshal(b, msg)
 }
 
 // MarshalJSON implements json.Marshaler
-func (msg *DriverGetExistingBucketResponse) MarshalJSON() ([]byte, error) {
+func (msg *DriverGetBucketResponse) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseEnumNumbers:  false,
 		EmitUnpopulated: true,
@@ -289,7 +289,7 @@ func (msg *DriverGetExistingBucketResponse) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler
-func (msg *DriverGetExistingBucketResponse) UnmarshalJSON(b []byte) error {
+func (msg *DriverGetBucketResponse) UnmarshalJSON(b []byte) error {
 	return protojson.UnmarshalOptions{
 		DiscardUnknown: false,
 	}.Unmarshal(b, msg)

--- a/vendor/sigs.k8s.io/container-object-storage-interface/proto/cosi.proto
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/proto/cosi.proto
@@ -71,7 +71,7 @@ service Provisioner {
     // Important return codes:
     // - MUST return OK if a backend bucket with matching identity and parameters already exists.
     // - MUST return NOT_FOUND if a bucket with matching identity does not exist.
-    rpc DriverGetExistingBucket (DriverGetExistingBucketRequest) returns (DriverGetExistingBucketResponse) {}
+    rpc DriverGetBucket (DriverGetBucketRequest) returns (DriverGetBucketResponse) {}
 
     // Delete the bucket in the backend.
     //
@@ -322,13 +322,13 @@ message DriverCreateBucketResponse {
     ObjectProtocolAndBucketInfo protocols = 2;
 }
 
-message DriverGetExistingBucketRequest {
+message DriverGetBucketRequest {
     // REQUIRED. The unique identifier for the existing backend bucket known to the Provisioner.
     // Provisioner MUST be able to correlate `bucket_id` to the backend bucket.
     // It is RECOMMENDED to use the backend storage system's bucket ID.
     // To prevent abuse, this must be at most 2048 characters long, consisting of alphanumeric
     // characters ([a-z0-9A-Z]), dashes (-), and dots (.).
-    string existing_bucket_id = 1;
+    string bucket_id = 1;
 
     // OPTIONAL. A list of all object storage protocols the provisioned bucket MUST support.
     // If none are given, the provisioner MAY provision with a set of default protocol(s) or return
@@ -341,7 +341,7 @@ message DriverGetExistingBucketRequest {
     map<string, string> parameters = 4;
 }
 
-message DriverGetExistingBucketResponse {
+message DriverGetBucketResponse {
     // REQUIRED. The unique identifier for the backend bucket known to the Provisioner.
     // This value WILL be used by COSI to make subsequent calls related to the bucket, so the
     // Provisioner MUST be able to correlate `bucket_id` to the backend bucket.

--- a/vendor/sigs.k8s.io/container-object-storage-interface/proto/cosi_grpc.pb.go
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/proto/cosi_grpc.pb.go
@@ -114,7 +114,7 @@ var Identity_ServiceDesc = grpc.ServiceDesc{
 
 const (
 	Provisioner_DriverCreateBucket_FullMethodName       = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverCreateBucket"
-	Provisioner_DriverGetExistingBucket_FullMethodName  = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverGetExistingBucket"
+	Provisioner_DriverGetBucket_FullMethodName          = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverGetBucket"
 	Provisioner_DriverDeleteBucket_FullMethodName       = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverDeleteBucket"
 	Provisioner_DriverGrantBucketAccess_FullMethodName  = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverGrantBucketAccess"
 	Provisioner_DriverRevokeBucketAccess_FullMethodName = "/sigs.k8s.io.cosi.v1alpha2.Provisioner/DriverRevokeBucketAccess"
@@ -135,7 +135,7 @@ type ProvisionerClient interface {
 	// Important return codes:
 	// - MUST return OK if a backend bucket with matching identity and parameters already exists.
 	// - MUST return NOT_FOUND if a bucket with matching identity does not exist.
-	DriverGetExistingBucket(ctx context.Context, in *DriverGetExistingBucketRequest, opts ...grpc.CallOption) (*DriverGetExistingBucketResponse, error)
+	DriverGetBucket(ctx context.Context, in *DriverGetBucketRequest, opts ...grpc.CallOption) (*DriverGetBucketResponse, error)
 	// Delete the bucket in the backend.
 	//
 	// Important return codes:
@@ -172,9 +172,9 @@ func (c *provisionerClient) DriverCreateBucket(ctx context.Context, in *DriverCr
 	return out, nil
 }
 
-func (c *provisionerClient) DriverGetExistingBucket(ctx context.Context, in *DriverGetExistingBucketRequest, opts ...grpc.CallOption) (*DriverGetExistingBucketResponse, error) {
-	out := new(DriverGetExistingBucketResponse)
-	err := c.cc.Invoke(ctx, Provisioner_DriverGetExistingBucket_FullMethodName, in, out, opts...)
+func (c *provisionerClient) DriverGetBucket(ctx context.Context, in *DriverGetBucketRequest, opts ...grpc.CallOption) (*DriverGetBucketResponse, error) {
+	out := new(DriverGetBucketResponse)
+	err := c.cc.Invoke(ctx, Provisioner_DriverGetBucket_FullMethodName, in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ type ProvisionerServer interface {
 	// Important return codes:
 	// - MUST return OK if a backend bucket with matching identity and parameters already exists.
 	// - MUST return NOT_FOUND if a bucket with matching identity does not exist.
-	DriverGetExistingBucket(context.Context, *DriverGetExistingBucketRequest) (*DriverGetExistingBucketResponse, error)
+	DriverGetBucket(context.Context, *DriverGetBucketRequest) (*DriverGetBucketResponse, error)
 	// Delete the bucket in the backend.
 	//
 	// Important return codes:
@@ -251,8 +251,8 @@ type UnimplementedProvisionerServer struct {
 func (UnimplementedProvisionerServer) DriverCreateBucket(context.Context, *DriverCreateBucketRequest) (*DriverCreateBucketResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DriverCreateBucket not implemented")
 }
-func (UnimplementedProvisionerServer) DriverGetExistingBucket(context.Context, *DriverGetExistingBucketRequest) (*DriverGetExistingBucketResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DriverGetExistingBucket not implemented")
+func (UnimplementedProvisionerServer) DriverGetBucket(context.Context, *DriverGetBucketRequest) (*DriverGetBucketResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DriverGetBucket not implemented")
 }
 func (UnimplementedProvisionerServer) DriverDeleteBucket(context.Context, *DriverDeleteBucketRequest) (*DriverDeleteBucketResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DriverDeleteBucket not implemented")
@@ -294,20 +294,20 @@ func _Provisioner_DriverCreateBucket_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Provisioner_DriverGetExistingBucket_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DriverGetExistingBucketRequest)
+func _Provisioner_DriverGetBucket_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DriverGetBucketRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ProvisionerServer).DriverGetExistingBucket(ctx, in)
+		return srv.(ProvisionerServer).DriverGetBucket(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: Provisioner_DriverGetExistingBucket_FullMethodName,
+		FullMethod: Provisioner_DriverGetBucket_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ProvisionerServer).DriverGetExistingBucket(ctx, req.(*DriverGetExistingBucketRequest))
+		return srv.(ProvisionerServer).DriverGetBucket(ctx, req.(*DriverGetBucketRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -378,8 +378,8 @@ var Provisioner_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _Provisioner_DriverCreateBucket_Handler,
 		},
 		{
-			MethodName: "DriverGetExistingBucket",
-			Handler:    _Provisioner_DriverGetExistingBucket_Handler,
+			MethodName: "DriverGetBucket",
+			Handler:    _Provisioner_DriverGetBucket_Handler,
 		},
 		{
 			MethodName: "DriverDeleteBucket",

--- a/vendor/sigs.k8s.io/container-object-storage-interface/proto/spec.md
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/proto/spec.md
@@ -118,7 +118,7 @@ service Provisioner {
     // Important return codes:
     // - MUST return OK if a backend bucket with matching identity and parameters already exists.
     // - MUST return NOT_FOUND if a bucket with matching identity does not exist.
-    rpc DriverGetExistingBucket (DriverGetExistingBucketRequest) returns (DriverGetExistingBucketResponse) {}
+    rpc DriverGetBucket (DriverGetBucketRequest) returns (DriverGetBucketResponse) {}
 
     // Delete the bucket in the backend.
     //
@@ -493,7 +493,7 @@ message DriverCreateBucketResponse {
 }
 ```
 
-#### DriverGetExistingBucket
+#### DriverGetBucket
 
 A Plugin MUST implement this RPC call.
 
@@ -506,13 +506,13 @@ Important return codes:
 * `InvalidArgument` (not retryable) if any parameters are invalid for the backend.
 
 ```protobuf
-message DriverGetExistingBucketRequest {
+message DriverGetBucketRequest {
     // REQUIRED. The unique identifier for the existing backend bucket known to the Provisioner.
     // Provisioner MUST be able to correlate `bucket_id` to the backend bucket.
     // It is RECOMMENDED to use the backend storage system's bucket ID.
     // To prevent abuse, this must be at most 2048 characters long, consisting of alphanumeric
     // characters ([a-z0-9A-Z]), dashes (-), and dots (.).
-    string existing_bucket_id = 1;
+    string bucket_id = 1;
 
     // OPTIONAL. A list of all object storage protocols the provisioned bucket MUST support.
     // If none are given, the provisioner MAY provision with a set of default protocol(s) or return
@@ -525,7 +525,7 @@ message DriverGetExistingBucketRequest {
     map<string, string> parameters = 4;
 }
 
-message DriverGetExistingBucketResponse {
+message DriverGetBucketResponse {
     // REQUIRED. The unique identifier for the backend bucket known to the Provisioner.
     // This value WILL be used by COSI to make subsequent calls related to the bucket, so the
     // Provisioner MUST be able to correlate `bucket_id` to the backend bucket.


### PR DESCRIPTION
Renames the `DriverGetExistingBucket` RPC, its `Request`/`Response` messages, and the request's `existing_bucket_id` field to `DriverGetBucket`/`bucket_id`, per KEP review feedback (kubernetes/enhancements#4599) to use more generic naming for future usage. First of 2 PRs from that review comment; a follow-up will add response protocol-support validation and tests.

## Test plan
- [x] `go build`/`go vet` pass (root and `proto/` modules)
- [x] `go test ./sidecar/... ./internal/... ./controller/...` and `make -C proto check` pass
- [x] No leftover `GetExistingBucket`/`existing_bucket_id` references anywhere in the repo

Resolves #347 