### PR TITLE
sidecar: validate Bucket driverName before granting BucketAccess

### DIFF
--- a/sidecar/pkg/reconciler/bucketaccess.go
+++ b/sidecar/pkg/reconciler/bucketaccess.go
@@ -169,7 +169,7 @@ func (r *BucketAccessReconciler) reconcile(
 		}
 	}
 
-	if err := getAndValidateAllAccessedBuckets(ctx, r.Client, access, r.DriverInfo.Name); err != nil {
+	if err := r.getAndValidateAllAccessedBuckets(ctx, access); err != nil {
 		logger.Error(err, "failed to validate accessed Buckets for BucketAccess")
 		return err
 	}
@@ -624,8 +624,8 @@ func (r *BucketAccessReconciler) updateSecretsWithGrantedInfo(
 
 // Get all Buckets from BucketAccess status. Error if any Bucket Get() fails.
 // Validate that all gotten buckets are ready for access.
-func getAndValidateAllAccessedBuckets(
-	ctx context.Context, client client.Client, access *cosiapi.BucketAccess, driverName string,
+func (r *BucketAccessReconciler) getAndValidateAllAccessedBuckets(
+	ctx context.Context, access *cosiapi.BucketAccess,
 ) error {
 	errs := []error{}
 
@@ -636,7 +636,7 @@ func getAndValidateAllAccessedBuckets(
 		}
 
 		bkt := &cosiapi.Bucket{}
-		err := client.Get(ctx, nsName, bkt)
+		err := r.Client.Get(ctx, nsName, bkt)
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				errs = append(errs, cosierr.NonRetryableError(err))
@@ -648,7 +648,7 @@ func getAndValidateAllAccessedBuckets(
 			continue
 		}
 
-		if err := validateBucketIsReadyForAccess(bkt, ab.BucketID, driverName); err != nil {
+		if err := r.validateBucketIsReadyForAccess(bkt, ab.BucketID); err != nil {
 			errs = append(errs, cosierr.NonRetryableError(err))
 			continue
 		}
@@ -661,7 +661,7 @@ func getAndValidateAllAccessedBuckets(
 	return nil
 }
 
-func validateBucketIsReadyForAccess(b *cosiapi.Bucket, expectedBucketID string, expectedDriverName string) error {
+func (r *BucketAccessReconciler) validateBucketIsReadyForAccess(b *cosiapi.Bucket, expectedBucketID string) error {
 	errs := []error{}
 
 	if _, ok := b.Annotations[cosiapi.BucketClaimBeingDeletedAnnotation]; ok {
@@ -685,12 +685,12 @@ func validateBucketIsReadyForAccess(b *cosiapi.Bucket, expectedBucketID string, 
 			b.Name, b.Status.BucketID, expectedBucketID))
 	}
 
-	if b.Spec.DriverName != expectedDriverName {
+	if b.Spec.DriverName != r.DriverInfo.Name {
 		// A Bucket must never be granted access by a driver other than the one that
 		// provisioned it, even if a BucketAccessClass claims to use this driver.
 		//nolint:staticcheck // ST1005: okay to capitalize resource kind
 		errs = append(errs, fmt.Errorf("Bucket %q driverName %q does not match expected driverName %q",
-			b.Name, b.Spec.DriverName, expectedDriverName))
+			b.Name, b.Spec.DriverName, r.DriverInfo.Name))
 	}
 
 	if len(errs) > 0 {

--- a/sidecar/pkg/reconciler/bucketaccess.go
+++ b/sidecar/pkg/reconciler/bucketaccess.go
@@ -169,7 +169,7 @@ func (r *BucketAccessReconciler) reconcile(
 		}
 	}
 
-	if err := getAndValidateAllAccessedBuckets(ctx, r.Client, access); err != nil {
+	if err := getAndValidateAllAccessedBuckets(ctx, r.Client, access, r.DriverInfo.Name); err != nil {
 		logger.Error(err, "failed to validate accessed Buckets for BucketAccess")
 		return err
 	}
@@ -625,7 +625,7 @@ func (r *BucketAccessReconciler) updateSecretsWithGrantedInfo(
 // Get all Buckets from BucketAccess status. Error if any Bucket Get() fails.
 // Validate that all gotten buckets are ready for access.
 func getAndValidateAllAccessedBuckets(
-	ctx context.Context, client client.Client, access *cosiapi.BucketAccess,
+	ctx context.Context, client client.Client, access *cosiapi.BucketAccess, driverName string,
 ) error {
 	errs := []error{}
 
@@ -648,7 +648,7 @@ func getAndValidateAllAccessedBuckets(
 			continue
 		}
 
-		if err := validateBucketIsReadyForAccess(bkt, ab.BucketID); err != nil {
+		if err := validateBucketIsReadyForAccess(bkt, ab.BucketID, driverName); err != nil {
 			errs = append(errs, cosierr.NonRetryableError(err))
 			continue
 		}
@@ -661,7 +661,7 @@ func getAndValidateAllAccessedBuckets(
 	return nil
 }
 
-func validateBucketIsReadyForAccess(b *cosiapi.Bucket, expectedBucketID string) error {
+func validateBucketIsReadyForAccess(b *cosiapi.Bucket, expectedBucketID string, expectedDriverName string) error {
 	errs := []error{}
 
 	if _, ok := b.Annotations[cosiapi.BucketClaimBeingDeletedAnnotation]; ok {
@@ -683,6 +683,14 @@ func validateBucketIsReadyForAccess(b *cosiapi.Bucket, expectedBucketID string) 
 		//nolint:staticcheck // ST1005: okay to capitalize resource kind
 		errs = append(errs, fmt.Errorf("Bucket %q ID %q does not match expected ID %q",
 			b.Name, b.Status.BucketID, expectedBucketID))
+	}
+
+	if b.Spec.DriverName != expectedDriverName {
+		// A Bucket must never be granted access by a driver other than the one that
+		// provisioned it, even if a BucketAccessClass claims to use this driver.
+		//nolint:staticcheck // ST1005: okay to capitalize resource kind
+		errs = append(errs, fmt.Errorf("Bucket %q driverName %q does not match expected driverName %q",
+			b.Name, b.Spec.DriverName, expectedDriverName))
 	}
 
 	if len(errs) > 0 {

--- a/sidecar/pkg/reconciler/bucketaccess_test.go
+++ b/sidecar/pkg/reconciler/bucketaccess_test.go
@@ -74,7 +74,9 @@ func TestBucketAccessReconciler_Reconcile(t *testing.T) {
 			Name: "s3-class",
 		},
 		Spec: cosiapi.BucketAccessClassSpec{
-			DriverName:         "cosi.s3.internal",
+			// must match the driver that provisions the Buckets used by these tests, i.e. the
+			// driver named by cositest.OpinionatedS3BucketClass()
+			DriverName:         cositest.OpinionatedS3BucketClass().Spec.DriverName,
 			AuthenticationType: cosiapi.BucketAccessAuthenticationTypeKey,
 			Parameters: map[string]string{
 				"maxSize": "100Gi",
@@ -95,7 +97,7 @@ func TestBucketAccessReconciler_Reconcile(t *testing.T) {
 			Client: api,
 			Scheme: api.Scheme(),
 			DriverInfo: sidecar.DriverInfo{
-				Name:               "cosi.s3.internal",
+				Name:               cositest.OpinionatedS3BucketClass().Spec.DriverName,
 				SupportedProtocols: []cosiproto.ObjectProtocol_Type{cosiproto.ObjectProtocol_S3},
 				ProvisionerClient:  proto,
 			},
@@ -1082,6 +1084,82 @@ func TestBucketAccessReconciler_Reconcile(t *testing.T) {
 
 		t.Run("subsequent deletion", func(t *testing.T) {
 			bootstrapped, r := testBucketDeletingAnnotation(t)
+			testDeletionWhenRpcShouldNotBeCalled(t, bootstrapped, r)
+		})
+	})
+
+	t.Run("a bucket was provisioned by a different driver", func(t *testing.T) {
+		fakeServer := cositest.FakeProvisionerServer{} // no RPC calls should be made
+
+		cleanup, serve, tmpSock, err := cositest.RpcServer(nil, &fakeServer)
+		defer cleanup()
+		require.NoError(t, err)
+		go serve()
+
+		conn, err := cositest.RpcClientConn(tmpSock)
+		require.NoError(t, err)
+		rpcClient := cosiproto.NewProvisionerClient(conn)
+
+		testBucketDriverNameMismatch := func(t *testing.T) (
+			bootstrapped *cositest.Dependencies,
+			reconciler *sidecar.BucketAccessReconciler,
+		) {
+			bootstrapped = cositest.MustBootstrap(t,
+				baseAccess.DeepCopy(),
+				baseClass.DeepCopy(),
+				baseReadWriteClaim.DeepCopy(),
+				baseReadOnlyClaim.DeepCopy(),
+				cositest.OpinionatedS3BucketClass(),
+			)
+			ctx := bootstrapped.ContextWithLogger
+
+			reconcileBucketClaimsAndAccessInitialization(t, bootstrapped)
+			initAccess, initRwBucket, initRoBucket, _, _ := getAllResources(bootstrapped)
+
+			// Simulate a Bucket that was actually provisioned by a different driver than the one
+			// named by the BucketAccessClass/BucketAccess. This must never be granted access by
+			// this reconciler's driver.
+			mismatchedBucket := initRwBucket.DeepCopy()
+			mismatchedBucket.Spec.DriverName = "some-other-driver"
+			require.NoError(t, bootstrapped.Client.Update(ctx, mismatchedBucket))
+
+			r := newReconciler(bootstrapped.Client, rpcClient)
+
+			res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseAccess)})
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, reconcile.TerminalError(nil))
+			assert.Empty(t, res)
+
+			access, rwBucket, roBucket, _, _ := getAllResources(bootstrapped)
+
+			assert.Contains(t, access.GetFinalizers(), cosiapi.ProtectionFinalizer)
+			assert.Equal(t, baseAccess.Spec, access.Spec)
+			require.NotNil(t, access.Status.Error)
+			assert.NotNil(t, access.Status.Error.Time)
+			assert.NotNil(t, access.Status.Error.Message)
+			assert.Contains(t, *access.Status.Error.Message, mismatchedBucket.Name)
+			assert.Contains(t, *access.Status.Error.Message, "some-other-driver")
+			{ // non-error fields stay the same
+				accessNoError := access.DeepCopy()
+				accessNoError.Status.Error = nil
+				assert.Equal(t, initAccess.Status, accessNoError.Status)
+			}
+
+			// don't care if secrets exist
+
+			// buckets must not be changed
+			assert.Equal(t, mismatchedBucket, rwBucket)
+			assert.Equal(t, initRoBucket, roBucket)
+
+			return bootstrapped, &r
+		}
+
+		t.Run("reconcile", func(t *testing.T) {
+			testBucketDriverNameMismatch(t)
+		})
+
+		t.Run("subsequent deletion", func(t *testing.T) {
+			bootstrapped, r := testBucketDriverNameMismatch(t)
 			testDeletionWhenRpcShouldNotBeCalled(t, bootstrapped, r)
 		})
 	})


### PR DESCRIPTION
Motivation:
The Sidecar's BucketAccessReconciler validated that a referenced
Bucket exists, isn't deleting, and has the expected bucketID before
asking the driver to grant access to it, but never checked that the
Bucket was actually provisioned by this same driver. The reconciler's
only existing driver check compares access.Status.DriverName (copied
from the BucketAccessClass by the central Controller) against the
Sidecar's own driver name; it does not verify that the underlying
Bucket resources were actually provisioned by that driver. If a
BucketAccessClass names a driver that does not match the driver that
actually owns the referenced Bucket, the Sidecar would still issue a
DriverGrantBucketAccess RPC call for a bucket ID it does not own.

Approach:
Add a check in validateBucketIsReadyForAccess (sidecar/pkg/reconciler/
bucketaccess.go) that Bucket.Spec.DriverName (the immutable field set
by the Controller from BucketClass.Spec.DriverName at provisioning
time) matches the driver's own name before generating access,
returning a non-retryable error otherwise. This rejects the mismatch
locally before an RPC is attempted, rather than relying on the
backend driver to reject an unrecognized bucket ID.

While adding a test for this, it became apparent that the existing
sidecar BucketAccess reconciler test suite's shared S3 fixtures
(baseClass.Spec.DriverName and newReconciler's DriverInfo.Name) were
hardcoded to a driver name ("cosi.s3.internal") that did not actually
match the driver name of the Buckets the same tests provision via the
shared cositest.OpinionatedS3BucketClass() helper ("s3.cosi.test").
This means the whole existing S3 test suite was unknowingly already
exercising the "different driver" scenario this issue describes,
without any assertion catching it. Fixed both fixtures to reference
cositest.OpinionatedS3BucketClass().Spec.DriverName, matching the
pattern already used by this same file's Azure and GCS test sections.

Impact:
Before this change, user-visible behavior for a correctly matched
Bucket/driver was unchanged; this only closes a gap for a mismatched
one. Per prior maintainer comment on the report, a mismatch previously
surfaced as a driver RPC error for an unrecognized bucket ID; after
this change it is instead rejected earlier, inside the Sidecar, with a
clearer, more specific error message before any RPC call is made. This
is a defense-in-depth validation added to the Sidecar; it does not
change the initial BucketAccess/Bucket provisioning validation done by
the central Controller.

Validation:
Ran `go build ./...` (clean) and `go test ./sidecar/... ./internal/...
./controller/...` (all pass), including the new
"a bucket was provisioned by a different driver" subtest under
TestBucketAccessReconciler_Reconcile in
sidecar/pkg/reconciler/bucketaccess_test.go, which mutates a Bucket's
spec.driverName to a different value and asserts the reconcile fails
with a terminal, non-retryable error naming the mismatched Bucket and
driver, and that a subsequent deletion reconcile still succeeds
without invoking the driver's revoke RPC. Also confirmed the existing
full sidecar/controller unit test suite still passes after correcting
the pre-existing test-fixture driver name mismatch described above.
golangci-lint was not run locally (binary unavailable in this
environment); gofmt -l reported no formatting issues on the changed
files.

Report: https://github.com/kubernetes-sigs/container-object-storage-interface/issues/245
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.

Fixes #245

```release-note
sidecar: validate Bucket driverName before granting BucketAccess
```