### PR TITLE
Generate controller RBAC from kubebuilder markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,7 @@ generate: crds rbac controller/Dockerfile sidecar/Dockerfile ## Generate files
 crds: controller-gen
 	cd ./client && $(CONTROLLER_GEN) crd paths="./apis/objectstorage/..."
 
-# RBAC markers live on the reconcilers in the root module, so this cannot be generated from
-# ./client (a separate Go module) alongside the CRDs.
+# Gen Controller RBAC from kubebuilder markers in reconciler go files
 .PHONY: rbac
 rbac: controller-gen
 	$(CONTROLLER_GEN) rbac:roleName=controller-role paths="./controller/pkg/reconciler/..." \

--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,18 @@ build.sidecar: sidecar/Dockerfile ## Build only the sidecar container image
 	$(DOCKER) build --file sidecar/Dockerfile --platform $(PLATFORM) $(BUILD_ARGS) --tag $(SIDECAR_TAG) .
 
 .PHONY: generate
-generate: crds controller/Dockerfile sidecar/Dockerfile ## Generate files
+generate: crds rbac controller/Dockerfile sidecar/Dockerfile ## Generate files
 
 .PHONY: crds
 crds: controller-gen
-	cd ./client && $(CONTROLLER_GEN) rbac:roleName=manager-role crd paths="./apis/objectstorage/..."
+	cd ./client && $(CONTROLLER_GEN) crd paths="./apis/objectstorage/..."
+
+# RBAC markers live on the reconcilers in the root module, so this cannot be generated from
+# ./client (a separate Go module) alongside the CRDs.
+.PHONY: rbac
+rbac: controller-gen
+	$(CONTROLLER_GEN) rbac:roleName=controller-role paths="./controller/pkg/reconciler/..." \
+		output:rbac:artifacts:config=controller/resources
 
 %/Dockerfile: hack/Dockerfile.in hack/gen-dockerfile.sh
 	hack/gen-dockerfile.sh $* > "$@"

--- a/controller/kustomization.yaml
+++ b/controller/kustomization.yaml
@@ -16,4 +16,5 @@ resources:
   - resources/deployment.yaml
   - resources/namespace.yaml
   - resources/rbac.yaml
+  - resources/role.yaml
   - resources/sa.yaml

--- a/controller/pkg/reconciler/bucket.go
+++ b/controller/pkg/reconciler/bucket.go
@@ -33,8 +33,8 @@ type BucketReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=buckets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=buckets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=buckets,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=buckets/status,verbs=get;update
 // +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=buckets/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/controller/pkg/reconciler/bucketaccess.go
+++ b/controller/pkg/reconciler/bucketaccess.go
@@ -46,9 +46,10 @@ type BucketAccessReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketaccesses,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketaccesses,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketaccesses/status,verbs=get;update
 // +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketaccesses/finalizers,verbs=update
+// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketaccessclasses,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controller/pkg/reconciler/bucketclaim.go
+++ b/controller/pkg/reconciler/bucketclaim.go
@@ -45,10 +45,11 @@ type BucketClaimReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketclaims,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketclaims,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketclaims/status,verbs=get;update
 // +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketclaims/finalizers,verbs=update
-// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=buckets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=buckets,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/controller/resources/rbac.yaml
+++ b/controller/resources/rbac.yaml
@@ -1,21 +1,5 @@
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: controller-role
-rules:
-  - apiGroups: ["objectstorage.k8s.io"]
-    resources: ["bucketclaims", "bucketaccesses", "bucketclaims/status", "bucketaccesses/status"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["objectstorage.k8s.io"]
-    resources: ["buckets"]
-    verbs: ["get", "list", "watch", "update", "create", "delete"]
-  - apiGroups: ["objectstorage.k8s.io"]
-    resources: ["bucketclasses","bucketaccessclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create"]
+# NOTE: the controller-role ClusterRole is generated into role.yaml from the +kubebuilder:rbac
+# markers on the reconcilers. Run 'make rbac' after changing those markers.
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/controller/resources/role.yaml
+++ b/controller/resources/role.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: controller-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - objectstorage.k8s.io
+  resources:
+  - bucketaccessclasses
+  - bucketclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - objectstorage.k8s.io
+  resources:
+  - bucketaccesses
+  - bucketclaims
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - objectstorage.k8s.io
+  resources:
+  - bucketaccesses/finalizers
+  - bucketclaims/finalizers
+  - buckets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - objectstorage.k8s.io
+  resources:
+  - bucketaccesses/status
+  - bucketclaims/status
+  - buckets/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - objectstorage.k8s.io
+  resources:
+  - buckets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Takes option 1 from #152: use the `+kubebuilder:rbac` markers to generate RBAC, rather than deleting them.

The markers were never actually read. `make crds` ran:

```
cd ./client && $(CONTROLLER_GEN) rbac:roleName=manager-role crd paths="./apis/objectstorage/..."
```

`client/` is a separate Go module containing only API types, so controller-gen found no markers there and emitted nothing. The real ClusterRole was hand-maintained in `controller/resources/rbac.yaml`, and the two had drifted:

- `bucketclasses` / `bucketaccessclasses` are read by the controller (`bucketclaim.go`, `bucketaccess.go`) and granted in `rbac.yaml`, but no marker covered them. Repointing `paths=` alone would have generated a ClusterRole missing those rules and broken the controller at runtime.
- Markers requested `patch` on `buckets` and `buckets/status`. There are no `.Patch()` calls in the controller and `rbac.yaml` grants no `patch`.
- Markers requested `create` on `bucketclaims` and `bucketaccesses`. The controller only creates Buckets; `rbac.yaml` grants neither.

Changes:

- Add a `make rbac` target that runs controller-gen from the root module, so it can see the reconcilers. This can't be folded into the existing `crds` target because that runs inside the `client/` module.
- Correct the markers to match what the code actually does.
- Generate `controller-role` into `controller/resources/role.yaml` and reference it from `controller/kustomization.yaml`.
- Drop the hand-written ClusterRole from `rbac.yaml`, keeping the bindings and the leader-election Role there — those are deployment concerns and aren't derivable from reconciler code.

The generated ClusterRole grants the same permissions the hand-written one did, plus the standard `*/finalizers` update rules. No permission is removed, so existing deployments are unaffected.

`make generate` is already covered by `hack/prow-check-generate.sh`, so the markers and the ClusterRole can no longer drift apart.

**Which issue(s) this PR fixes:**

Fixes #152

**Notes for reviewers:**

Scoped to the controller. The sidecar has 6 markers but no RBAC manifest in the repo at all, so generating a role for it means deciding whether the sidecar ships one — happy to do that here or as a follow-up, whichever you prefer.

Also noticed `events: create` is granted in both the markers and `rbac.yaml`, but there is no `EventRecorder` anywhere in the codebase. Left it alone since the reconcilers have "report an event for" comments suggesting it's intended, but flagging it.

Verified locally: `go build ./...`, `go test ./controller/... ./sidecar/...`, `make lint`, and `kubectl kustomize .` (bindings still resolve to the generated role name after the `namePrefix` rewrite). Re-running `make generate` produces no diff.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

---

This change was prepared with AI assistance; all changes were reviewed and verified by me.
