### PR TITLE
Fix inconsistent wording in comment of BucketAccessModes

### DIFF
--- a/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
+++ b/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
@@ -40,7 +40,7 @@ const (
 // have for a bucket. At least one category must be set.
 // +kubebuilder:validation:MinProperties=1
 type BucketAccessModes struct {
-	// objectData requests Read/Write access to the objects in a bucket.
+	// objectData controls Read/Write access to the objects in a bucket.
 	// Unspecified means any access may be provisioned, including no access.
 	// Possible values: 'ReadWrite', 'ReadOnly', 'WriteOnly'.
 	// +optional

--- a/client/config/crd/objectstorage.k8s.io_bucketaccesses.yaml
+++ b/client/config/crd/objectstorage.k8s.io_bucketaccesses.yaml
@@ -86,7 +86,7 @@ spec:
                           type: string
                         objectData:
                           description: |-
-                            objectData requests Read/Write access to the objects in a bucket.
+                            objectData controls Read/Write access to the objects in a bucket.
                             Unspecified means any access may be provisioned, including no access.
                             Possible values: 'ReadWrite', 'ReadOnly', 'WriteOnly'.
                           enum:

--- a/docs/src/api/out.md
+++ b/docs/src/api/out.md
@@ -216,7 +216,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `objectData` _[BucketAccessMode](#bucketaccessmode)_ | objectData requests Read/Write access to the objects in a bucket.<br />Unspecified means any access may be provisioned, including no access.<br />Possible values: 'ReadWrite', 'ReadOnly', 'WriteOnly'. |  | Enum: [ReadWrite ReadOnly WriteOnly] <br /> |
+| `objectData` _[BucketAccessMode](#bucketaccessmode)_ | objectData controls Read/Write access to the objects in a bucket.<br />Unspecified means any access may be provisioned, including no access.<br />Possible values: 'ReadWrite', 'ReadOnly', 'WriteOnly'. |  | Enum: [ReadWrite ReadOnly WriteOnly] <br /> |
 | `objectMetadata` _[BucketAccessMode](#bucketaccessmode)_ | objectMetadata controls Read/Write access to the metadata on objects in a bucket.<br />Unspecified means any access may be provisioned, including no access.<br />Possible values: 'ReadWrite', 'ReadOnly', 'WriteOnly'. |  | Enum: [ReadWrite ReadOnly WriteOnly] <br /> |
 | `bucketMetadata` _[BucketAccessMode](#bucketaccessmode)_ | bucketMetadata controls Read/Write access to the metadata on the bucket itself.<br />Unspecified means any access may be provisioned, including no access.<br />Possible values: 'ReadWrite', 'ReadOnly', 'WriteOnly'. |  | Enum: [ReadWrite ReadOnly WriteOnly] <br /> |
 

--- a/vendor/sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
+++ b/vendor/sigs.k8s.io/container-object-storage-interface/client/apis/objectstorage/v1alpha2/bucketaccess_types.go
@@ -40,7 +40,7 @@ const (
 // have for a bucket. At least one category must be set.
 // +kubebuilder:validation:MinProperties=1
 type BucketAccessModes struct {
-	// objectData requests Read/Write access to the objects in a bucket.
+	// objectData controls Read/Write access to the objects in a bucket.
 	// Unspecified means any access may be provisioned, including no access.
 	// Possible values: 'ReadWrite', 'ReadOnly', 'WriteOnly'.
 	// +optional


### PR DESCRIPTION
This PR addresses an inconsistency in the k8s facing API comment in `bucketaccess_types.go`.