### PR TITLE
fix check for deletion when clearing status errors

### DIFF
--- a/controller/pkg/reconciler/bucketclaim.go
+++ b/controller/pkg/reconciler/bucketclaim.go
@@ -96,7 +96,7 @@ func (r *BucketClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// On success, clear any errors in the status.
-	if claim.Status.Error != nil && !claim.DeletionTimestamp.IsZero() {
+	if claim.Status.Error != nil && claim.DeletionTimestamp.IsZero() {
 		if claim.Status.ReadyToUse == nil {
 			claim.Status.ReadyToUse = ptr.To(false)
 		}

--- a/sidecar/pkg/reconciler/bucket.go
+++ b/sidecar/pkg/reconciler/bucket.go
@@ -91,7 +91,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// On success, clear any errors in the status.
-	if bucket.Status.Error != nil && !bucket.DeletionTimestamp.IsZero() {
+	if bucket.Status.Error != nil && bucket.DeletionTimestamp.IsZero() {
 		if bucket.Status.ReadyToUse == nil {
 			bucket.Status.ReadyToUse = ptr.To(false)
 		}


### PR DESCRIPTION
When clearing status errors on a successful reconcile, COSI should do that when the resource is **not** deleting. There was a typo that made it to Sidecar Bucket reconciliation and Controller BucketClaim reconciliation that only cleared errors on a successful reconcile when the resource **is** deleting -- a bug.