### PR TITLE
fix(release-0.2): set BucketName when sidecar marks claim ready

### DIFF
--- a/sidecar/pkg/bucket/bucket_controller.go
+++ b/sidecar/pkg/bucket/bucket_controller.go
@@ -162,6 +162,7 @@ func (b *BucketListener) Add(ctx context.Context, inputBucket *v1alpha1.Bucket) 
 				return b.recordError(bucket, v1.EventTypeWarning, v1alpha1.FailedCreateBucket, err)
 			}
 
+			bucketClaim.Status.BucketName = bucket.Name
 			bucketClaim.Status.BucketReady = true
 			if _, err = b.bucketClaims(bucketClaim.Namespace).UpdateStatus(ctx, bucketClaim, metav1.UpdateOptions{}); err != nil {
 				klog.V(3).ErrorS(err, "Failed to update bucketClaim",

--- a/sidecar/pkg/bucket/bucket_controller_test.go
+++ b/sidecar/pkg/bucket/bucket_controller_test.go
@@ -350,3 +350,80 @@ func TestAddDeletedBucket(t *testing.T) {
 		t.Fatalf("Add returned error for deleted bucket: %v", err)
 	}
 }
+
+// TestAddSetsBucketClaimBucketName is a regression test for
+// https://github.com/kubernetes-sigs/container-object-storage-interface/issues/285
+//
+// It reproduces the delayed existingBucketName scenario deterministically:
+// the BucketClaim's own status has not yet recorded BucketName when the
+// sidecar reconciles the Bucket it points to. The sidecar must set
+// BucketName alongside BucketReady, since a subsequent BucketClaim
+// reconcile short-circuits on BucketReady==true and can never repair it.
+func TestAddSetsBucketClaimBucketName(t *testing.T) {
+	driver := "driver1"
+	namespace := "default"
+	bucketName := "existing-bucket"
+	claimName := "test-claim"
+
+	bucketClaim := &v1alpha1.BucketClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.BucketClaimSpec{
+			ExistingBucketName: bucketName,
+		},
+		Status: v1alpha1.BucketClaimStatus{
+			BucketName:  "",
+			BucketReady: false,
+		},
+	}
+
+	bucket := &v1alpha1.Bucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: bucketName,
+		},
+		Spec: v1alpha1.BucketSpec{
+			DriverName:      driver,
+			BucketClassName: "test-bucket-class",
+			BucketClaim: &v1.ObjectReference{
+				Name:      claimName,
+				Namespace: namespace,
+			},
+		},
+	}
+
+	mpc := struct{ fakespec.FakeProvisionerClient }{}
+	mpc.FakeDriverCreateBucket = func(
+		_ context.Context,
+		_ *cosi.DriverCreateBucketRequest,
+		_ ...grpc.CallOption,
+	) (*cosi.DriverCreateBucketResponse, error) {
+		return &cosi.DriverCreateBucketResponse{BucketId: "backend-bucket-id"}, nil
+	}
+
+	client := fakebucketclientset.NewSimpleClientset(bucketClaim, bucket)
+
+	bl := BucketListener{
+		driverName:        driver,
+		provisionerClient: &mpc,
+	}
+	bl.InitializeBucketClient(client)
+
+	if err := bl.Add(context.TODO(), bucket); err != nil {
+		t.Fatalf("Add returned unexpected error: %v", err)
+	}
+
+	got, err := client.ObjectstorageV1alpha1().BucketClaims(namespace).Get(context.TODO(), claimName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to fetch BucketClaim: %v", err)
+	}
+
+	if !got.Status.BucketReady {
+		t.Errorf("expected BucketClaim.Status.BucketReady to be true, got false")
+	}
+
+	if got.Status.BucketName != bucket.Name {
+		t.Errorf("expected BucketClaim.Status.BucketName to be %q, got %q", bucket.Name, got.Status.BucketName)
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes #285 for the v1alpha1 implementation on `release-0.2`.

When a `BucketClaim` with `existingBucketName` is reconciled before the referenced `Bucket` exists, the sidecar can later reconcile the Bucket and set `BucketClaim.Status.BucketReady = true` without setting `BucketClaim.Status.BucketName`.

Because the BucketClaim controller short-circuits once `BucketReady` is true, the claim can remain in the inconsistent state `BucketReady=true` with an empty `BucketName`, preventing `BucketAccess` reconciliation.

This change sets `BucketClaim.Status.BucketName` to the reconciled Bucket name in the same sidecar status update that marks the claim ready.

It also adds regression coverage for the delayed `existingBucketName` binding path.

## Why release-0.2 only

Issue #285 affects the v1alpha1 implementation on `release-0.2`.

`main` uses the newer v1alpha2 reconciler architecture, where this flow is handled differently. PR #318 added regression coverage for the delayed binding scenario on `main`.

## Testing

* [x] `go test ./sidecar/pkg/bucket/... -v`
* [x] `make test.sidecar`
* [x] `make test`
* [x] Confirmed the regression test fails before the production fix with an empty `BucketName` and passes after the fix

### Release note

```release-note
[sidecar] Keep v1alpha1 BucketClaim status consistent by setting BucketName when the sidecar marks a referenced BucketClaim ready.
```
