### PR TITLE
fix: handle bucket deletion during bucketclaim deletion

### DIFF
--- a/controller/pkg/reconciler/bucketclaim.go
+++ b/controller/pkg/reconciler/bucketclaim.go
@@ -339,14 +339,14 @@ func (r *BucketClaimReconciler) reconcileDelete(
 		return r.removeClaimFinalizer(ctx, logger, claim)
 
 	case cosiapi.BucketDeletionPolicyDelete:
+		if err := r.applyBucketClaimIsDeletingAnnotation(ctx, logger, bucket); err != nil {
+			return err
+		}
+
 		if !bucket.DeletionTimestamp.IsZero() {
 			logger.Info("still waiting for Bucket to be deleted")
 			// TODO: return nil when Bucket watcher is set up
 			return fmt.Errorf("still waiting for Bucket to be deleted")
-		}
-
-		if err := r.applyBucketClaimIsDeletingAnnotation(ctx, logger, bucket); err != nil {
-			return err
 		}
 
 		if err := r.Delete(ctx, bucket); err != nil {
@@ -379,6 +379,10 @@ func (r *BucketClaimReconciler) removeClaimFinalizer(
 func (r *BucketClaimReconciler) applyBucketClaimIsDeletingAnnotation(
 	ctx context.Context, logger logr.Logger, bucket *cosiapi.Bucket,
 ) error {
+	if _, ok := bucket.Annotations[cosiapi.BucketClaimBeingDeletedAnnotation]; ok {
+		return nil
+	}
+
 	if bucket.Annotations == nil {
 		bucket.Annotations = map[string]string{}
 	}

--- a/controller/pkg/reconciler/reconciler_test/bucketclaim_test.go
+++ b/controller/pkg/reconciler/reconciler_test/bucketclaim_test.go
@@ -334,6 +334,44 @@ func deletionTestSuite(t *testing.T,
 	})
 }
 
+// Regression test for #392: Bucket already deleting before BucketClaim delete reconciles.
+func TestBucketClaimReconcileDeleteRace(t *testing.T) {
+	initBootstrapped := dynamicInitializationTest(t)
+	bootstrapped := initBootstrapped.MustCopy() // copy prior test world state
+	ctx := bootstrapped.ContextWithLogger
+	r := claimReconcilerForClient(bootstrapped.Client)
+
+	initClaim, initBucket := getClaimAndBucket(bootstrapped)
+	require.NotNil(t, initBucket)
+
+	// give Bucket a finalizer like the Sidecar would
+	initBucket, err := sidecartest.ReconcileOpinionatedS3Bucket(t, bootstrapped, cositest.NsName(initBucket))
+	require.NoError(t, err)
+	require.Contains(t, initBucket.GetFinalizers(), cosiapi.ProtectionFinalizer)
+
+	initBucket.Spec.DeletionPolicy = cosiapi.BucketDeletionPolicyDelete
+	require.NoError(t, r.Update(ctx, initBucket))
+
+	require.NoError(t, r.Delete(ctx, initBucket)) // delete Bucket first
+
+	bucket := &cosiapi.Bucket{}
+	require.NoError(t, r.Get(ctx, cositest.NsName(initBucket), bucket))
+	assert.NotZero(t, bucket.GetDeletionTimestamp())
+	assert.NotContains(t, bucket.GetAnnotations(), cosiapi.BucketClaimBeingDeletedAnnotation)
+
+	require.NoError(t, r.Delete(ctx, initClaim)) // delete BucketClaim second
+
+	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: cositest.NsName(&baseDynamicClaim)})
+	assert.Error(t, err) // TODO: should be NoError when Bucket watcher is set up
+	assert.NotErrorIs(t, err, reconcile.TerminalError(nil))
+	assert.ErrorContains(t, err, "still waiting for Bucket to be deleted")
+	assert.Empty(t, res)
+
+	bucket = &cosiapi.Bucket{}
+	require.NoError(t, r.Get(ctx, cositest.NsName(initBucket), bucket))
+	assert.Contains(t, bucket.GetAnnotations(), cosiapi.BucketClaimBeingDeletedAnnotation)
+}
+
 func deletionTestSuiteWithoutBucket(t *testing.T,
 	deps *cositest.Dependencies,
 ) {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does

Fixes a race during BucketClaim deletion where a Bucket can already
have a deletion timestamp before the BucketClaim controller applies
the BucketClaimIsDeletingAnnotation.

The deletion annotation is now applied before waiting for Bucket
deletion to complete.

Also avoids an unnecessary API update when the annotation is already
present.

## Testing

- Added a regression test (`TestBucketClaimReconcileDeleteRace`) that reproduces the race: confirmed it fails against `main`, passes after the fix.
- Ran `go test ./controller/...`

Fixes #392
